### PR TITLE
feat(report): first-class HTML report

### DIFF
--- a/bridge/rector/FEATURE_PARITY.md
+++ b/bridge/rector/FEATURE_PARITY.md
@@ -32,6 +32,7 @@ Conversion coverage across the three directions supported by `testo/bridge-recto
 | **Memory-leak expectations** | ⛔ *no PHPUnit equivalent* | ➖ | ➖ |
 | **Retry / Repeat** (`#[Retry]`/`#[Repeat]`) | ⛔ *no PHPUnit equivalent* | ➖ | ➖ |
 | **Fiber** (`#[RunInFiber]`, `Coroutine::spawn/await/concurrently`) | ⛔ *no PHPUnit/Pest equivalent — neither has a fiber/coroutine test attribute or an in-test coroutine scope* | ➖ | ➖ |
+| **HTML report** (`HtmlPlugin`, `--log-html`) | ⛔ *not test code — a reporter configured in `testo.php` or by a flag, with nothing in a test file to convert* | ➖ | ➖ |
 | **`uses()`** (Pest) | ➖ | ➖ | ⛔ *a converted function has no base class, traits or `$this` to attach to; closures that capture `$this`-shared state are left untouched* |
 | **`arch()` tests** (Pest) | ➖ | ➖ | ⛔ *Testo has no arch-assertion subsystem* |
 

--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -152,6 +152,21 @@ final class Run extends Base
             . 'Flag name mirrors PHPUnit / Pest / ParaTest.',
         );
         $this->addOption(
+            'log-html',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Write a self-contained HTML report. A path ending in ".html" produces that single file; '
+            . 'anything else is a directory to fill with index.html and its assets. '
+            . 'The report opens over file:// with no server.',
+        );
+        // $this->addOption(
+        //     'log-report',
+        //     null,
+        //     InputOption::VALUE_REQUIRED,
+        //     'Write the full run as a versioned JSON document to the given path. '
+        //     . 'The data behind the HTML report, on its own, for CI and external tooling.',
+        // );
+        $this->addOption(
             'coverage-clover',
             null,
             InputOption::VALUE_REQUIRED,

--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -11,6 +11,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Testo\Application\Config\ApplicationConfig;
 use Testo\Application\Config\DefaultServicesConfig;
 use Testo\Application\Config\Internal\ConfigInflector;
+use Testo\Application\Config\RunConfiguration;
 use Testo\Application\Config\Plugin\ApplicationPlugins;
 use Testo\Application\Config\Plugin\PluginCollection;
 use Testo\Application\Config\Plugin\SuitePlugins;
@@ -67,6 +68,9 @@ final readonly class Application
             'inputArguments' => $inputArguments,
             'inputOptions' => $inputOptions,
         ];
+
+        # What was asked of this run, for reporters that describe it. Environment stays out of it.
+        $container->set(new RunConfiguration($configFile, $inputOptions, $inputArguments));
 
         # Bind reading provided config file
         $configFile === null or $container

--- a/core/Application/Config/Plugin/ApplicationPlugins.php
+++ b/core/Application/Config/Plugin/ApplicationPlugins.php
@@ -7,6 +7,7 @@ namespace Testo\Application\Config\Plugin;
 use Testo\Codecov\CodecovPlugin;
 use Testo\Common\PluginConfigurator;
 use Testo\Filter\FilterPlugin;
+use Testo\Output\Html\HtmlPlugin;
 use Testo\Output\JUnit\JUnitPlugin;
 
 $_ = [];
@@ -16,6 +17,8 @@ $_ = [];
 \class_exists(JUnitPlugin::class) and $_[] = new JUnitPlugin();
 # Inert shadow: stays dormant unless a `--coverage-*` report flag activates it.
 \class_exists(CodecovPlugin::class) and $_[] = new CodecovPlugin();
+# Inert shadow: stays dormant unless `--log-html` or `--log-report` activates it.
+\class_exists(HtmlPlugin::class) and $_[] = HtmlPlugin::inert();
 
 \define([__NAMESPACE__ . '\DEFAULT_APPLICATION_PLUGINS'][0], $_);
 unset($_);

--- a/core/Application/Config/RunConfiguration.php
+++ b/core/Application/Config/RunConfiguration.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Application\Config;
+
+use Internal\Path;
+
+/**
+ * What this particular run was told to do: the config file it read and the CLI input it was given.
+ *
+ * {@see ApplicationConfig} states what the project *can* run — every suite, every plugin. This states
+ * what was asked of one invocation, which is not derivable from it: `--filter`, `--group`, `--suite`
+ * and `--type` narrow a run without leaving a trace in any result. Reporters need both to describe a
+ * run honestly, so the container always holds an instance — an empty one when the application was
+ * built from a config object rather than from a command line.
+ *
+ * Environment variables are deliberately absent. A report is an artifact that gets committed, attached
+ * to a CI build and opened by whoever has the link; dumping the environment into it would publish
+ * every token the process was handed.
+ *
+ * @psalm-immutable
+ * @api
+ */
+final readonly class RunConfiguration
+{
+    /**
+     * @param Path|null $configFile Config file the run read, or null when none was found or the
+     *        application was built from a config object.
+     * @param array<string, mixed> $options CLI options as given, defaults included — the effective
+     *        input, not a curated subset. A consumer decides what of it is worth showing.
+     * @param array<string, mixed> $arguments CLI arguments as given.
+     */
+    public function __construct(
+        public ?Path $configFile = null,
+        public array $options = [],
+        public array $arguments = [],
+    ) {}
+
+    /**
+     * A single option's value, or `$default` when it was never given.
+     */
+    public function option(string $name, mixed $default = null): mixed
+    {
+        return $this->options[$name] ?? $default;
+    }
+
+    /**
+     * Options that carry something, with the empty and the switched-off ones dropped: `false`, `null`,
+     * an empty string and an empty array all mean "not asked for" on a Symfony command line, and a
+     * reporter listing them would describe defaults as decisions.
+     *
+     * @return array<string, mixed>
+     */
+    public function givenOptions(): array
+    {
+        return \array_filter(
+            $this->options,
+            static fn(mixed $value): bool => $value !== false && $value !== null
+                && $value !== '' && $value !== [],
+        );
+    }
+}

--- a/core/Output/Html/HtmlPlugin.php
+++ b/core/Output/Html/HtmlPlugin.php
@@ -6,21 +6,11 @@ namespace Testo\Output\Html;
 
 use Internal\Container\Container;
 use Internal\Path;
-use Psr\EventDispatcher\EventDispatcherInterface;
-use Testo\Application\Config\ApplicationConfig;
-use Testo\Application\Config\RunConfiguration;
-use Testo\Common\EventListenerCollector;
 use Testo\Common\PluginConfigurator;
-use Testo\Core\Context\RunResult;
-use Testo\Core\Report\ReportInfo;
-use Testo\Event\Report\ReportFileGenerated;
-use Testo\Event\Report\ReportFileGenerating;
-use Testo\Event\Framework\SessionFinished;
-use Testo\Event\Framework\SessionStarting;
-use Testo\Output\Html\Internal\DocumentBuilder;
-use Testo\Output\Html\Internal\Recorder;
+use Testo\Output\Html\Internal\Destination;
+use Testo\Output\Html\Internal\HtmlReportSink;
 use Testo\Output\Html\Internal\ReportInput;
-use Testo\Output\Html\Internal\Writer;
+use Testo\Output\Html\Internal\ReportKind;
 
 /**
  * Writes the run as a self-contained HTML report, and the document behind it as a standalone artifact.
@@ -50,11 +40,12 @@ use Testo\Output\Html\Internal\Writer;
  * ```
  *
  * An inert copy — {@see inert()} — is part of the application defaults, so the `--log-html=<path>` and
- * `--log-report=<path>` flags have something to activate without any change to `testo.php`. Instances are
- * independent, and an instance configured in code ignores the flags entirely: as with the JUnit reporter,
- * adding `--log-html` to a run whose config already registers this plugin yields two reports rather than a
- * redirected one. Drop the default first to pin the report to a single path:
- * `ApplicationPlugins::without(HtmlPlugin::class)->with(new HtmlPlugin('build/report'))`.
+ * `--log-report=<path>` flags have something to activate without any change to `testo.php`. An instance
+ * configured in code owns its slots and ignores the flags; only an instance with no destination of its
+ * own reads them, which is how the inert default gets activated. Every destination a run collects — from
+ * configured plugins and from flags — feeds a single {@see HtmlReportSink}: the document is built once
+ * and written to each, and a path named twice is written once. Drop the default to keep the report to a
+ * single configured path: `ApplicationPlugins::without(HtmlPlugin::class)->with(new HtmlPlugin('build/report'))`.
  *
  * @api
  */
@@ -62,24 +53,6 @@ final class HtmlPlugin implements PluginConfigurator
 {
     /** Where a report goes when nothing says otherwise: under the project's runtime directory. */
     public const DEFAULT_PATH = 'runtime/report';
-
-    /**
-     * Format id of the standalone document. Not plain `json`, which is what
-     * {@see \Testo\Output\Json\JsonPlugin} writes: both files are JSON and neither is the other's schema,
-     * so the id names the schema rather than the encoding.
-     */
-    private const DATA_FORMAT = 'testo-report';
-
-    /**
-     * The report is written from a `SessionFinished` listener, and so is the final summary. A lower
-     * priority runs later, which puts the write — and the announcement that follows it — after the
-     * summary: the reader gets the verdict without waiting for a large document to be serialized, and the
-     * path lands with every other artifact path a run states at its end.
-     */
-    private const LISTENER_PRIORITY = -100;
-
-    private readonly Recorder $recorder;
-    private readonly Writer $writer;
 
     /** Destination of the page, or null when no page was asked for. */
     private ?Path $htmlPath;
@@ -90,14 +63,9 @@ final class HtmlPlugin implements PluginConfigurator
     /**
      * Single-shot guard, matching {@see \Testo\Output\JUnit\JUnitPlugin}: one instance is shared by every
      * top-level run and by every nested {@see \Testo\Testing\Helper\TestRunner::runTest()} sub-run, and
-     * attaching twice would have an inner session overwrite the outer session's report.
+     * contributing twice would have an inner session write over the outer session's report.
      */
     private bool $configured = false;
-
-    private ?RunConfiguration $runConfiguration = null;
-
-    /** @var list<non-empty-string> */
-    private array $suiteNames = [];
 
     /**
      * @param non-empty-string|null $outputPath Directory to fill, or a `.html` file to write everything
@@ -118,8 +86,6 @@ final class HtmlPlugin implements PluginConfigurator
     ) {
         $this->htmlPath = self::path($outputPath);
         $this->dataPath = self::path($dataPath);
-        $this->recorder = new Recorder();
-        $this->writer = new Writer();
     }
 
     /**
@@ -141,45 +107,25 @@ final class HtmlPlugin implements PluginConfigurator
         }
         $this->configured = true;
 
-        # Constructor paths win, the same way the JUnit reporter resolves its own: the flags are consulted
-        # only for an instance given no destination at all, which is how the inert default gets activated.
-        # A reporter configured in code owns both of its slots — a flag filling the empty one would add an
-        # output behind the config's back, and the inert default is already writing that file.
-        if ($this->htmlPath === null && $this->dataPath === null) {
-            $input = $container->get(ReportInput::class);
-            $this->htmlPath = self::path($input->htmlPath);
-            $this->dataPath = self::path($input->dataPath);
-
-            if ($this->htmlPath === null && $this->dataPath === null) {
-                return;
-            }
+        $destinations = $this->destinations($container);
+        if ($destinations === []) {
+            return;
         }
 
-        $this->runConfiguration = $container->get(RunConfiguration::class);
-        $this->suiteNames = self::suiteNames($container);
+        # First contributor creates the run's sink and wires it; the rest add their destinations to it.
+        $sink = $container->has(HtmlReportSink::class)
+            ? $container->get(HtmlReportSink::class)
+            : self::createSink($container);
 
-        $listeners = $container->get(EventListenerCollector::class);
-        $this->recorder->configure($listeners);
-        $listeners->addListener(
-            SessionFinished::class,
-            $this->onSessionFinished(...),
-            self::LISTENER_PRIORITY,
-        );
+        $sink->contribute($this->messageLimit, ...$destinations);
+    }
 
-        # Registered after the listener that writes the files, so the late announcement follows the write.
-        $dispatcher = $container->get(EventDispatcherInterface::class);
-        foreach ($this->announced() as $info) {
-            $listeners->addListener(
-                SessionStarting::class,
-                static fn(): mixed => $dispatcher->dispatch(new ReportFileGenerating($info)),
-                self::LISTENER_PRIORITY,
-            );
-            $listeners->addListener(
-                SessionFinished::class,
-                static fn(): mixed => $dispatcher->dispatch(new ReportFileGenerated($info)),
-                self::LISTENER_PRIORITY,
-            );
-        }
+    private static function createSink(Container $container): HtmlReportSink
+    {
+        $sink = new HtmlReportSink($container);
+        $container->set($sink);
+
+        return $sink;
     }
 
     private static function path(?string $path): ?Path
@@ -188,57 +134,30 @@ final class HtmlPlugin implements PluginConfigurator
     }
 
     /**
-     * Every configured suite, including the ones that ran nothing: a suite filtered down to zero tests
-     * leaves no trace in the results, and a report that omitted it would read as "no such suite".
+     * This instance's destinations: its own if it was given any, otherwise whatever the CLI flags name.
      *
-     * @return list<non-empty-string>
+     * Constructor paths win — an instance configured in code never reads the flags, so a flag filling an
+     * empty slot cannot add an output behind the config's back. Only an instance with no destination of
+     * its own (the inert default) falls through to the flags.
+     *
+     * @return list<Destination>
      */
-    private static function suiteNames(Container $container): array
+    private function destinations(Container $container): array
     {
-        $names = [];
-        foreach ($container->get(ApplicationConfig::class)->suites as $suite) {
-            $names[] = $suite->name;
+        $destinations = [];
+        $this->htmlPath === null or $destinations[] = new Destination($this->htmlPath, ReportKind::Html, $this->name);
+        $this->dataPath === null or $destinations[] = new Destination($this->dataPath, ReportKind::Data, $this->name);
+
+        if ($destinations !== []) {
+            return $destinations;
         }
 
-        return $names;
-    }
+        $input = $container->get(ReportInput::class);
+        $html = self::path($input->htmlPath);
+        $data = self::path($input->dataPath);
+        $html === null or $destinations[] = new Destination($html, ReportKind::Html, $this->name);
+        $data === null or $destinations[] = new Destination($data, ReportKind::Data, $this->name);
 
-    /**
-     * The cards for whatever this instance was asked to write: the standalone document, the page, or both.
-     *
-     * @return list<ReportInfo>
-     */
-    private function announced(): array
-    {
-        $cards = [];
-        $this->dataPath === null or $cards[] = new ReportInfo(self::DATA_FORMAT, $this->name, $this->dataPath);
-        $this->htmlPath === null or $cards[] = new ReportInfo(
-            'html',
-            $this->name,
-            Writer::entryFile($this->htmlPath),
-        );
-
-        return $cards;
-    }
-
-    private function onSessionFinished(SessionFinished $event): void
-    {
-        $document = $this->build($event->result);
-
-        $this->dataPath === null or $this->writer->writeData($this->dataPath, $document);
-        $this->htmlPath === null or $this->writer->writeHtml($this->htmlPath, $document);
-    }
-
-    /**
-     * @return array<non-empty-string, mixed>
-     */
-    private function build(RunResult $result): array
-    {
-        return (new DocumentBuilder(
-            recorder: $this->recorder,
-            config: $this->runConfiguration ?? new RunConfiguration(),
-            messageLimit: $this->messageLimit,
-            suiteNames: $this->suiteNames,
-        ))->build($result);
+        return $destinations;
     }
 }

--- a/core/Output/Html/HtmlPlugin.php
+++ b/core/Output/Html/HtmlPlugin.php
@@ -55,10 +55,10 @@ final class HtmlPlugin implements PluginConfigurator
     public const DEFAULT_PATH = 'runtime/report';
 
     /** Destination of the page, or null when no page was asked for. */
-    private ?Path $htmlPath;
+    private readonly ?Path $htmlPath;
 
     /** Destination of the standalone document, or null when it was not asked for. */
-    private ?Path $dataPath;
+    private readonly ?Path $dataPath;
 
     /**
      * Single-shot guard, matching {@see \Testo\Output\JUnit\JUnitPlugin}: one instance is shared by every

--- a/core/Output/Html/HtmlPlugin.php
+++ b/core/Output/Html/HtmlPlugin.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html;
+
+use Internal\Container\Container;
+use Internal\Path;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\RunConfiguration;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Report\ReportInfo;
+use Testo\Event\Report\ReportFileGenerated;
+use Testo\Event\Report\ReportFileGenerating;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Output\Html\Internal\DocumentBuilder;
+use Testo\Output\Html\Internal\Recorder;
+use Testo\Output\Html\Internal\ReportInput;
+use Testo\Output\Html\Internal\Writer;
+
+/**
+ * Writes the run as a self-contained HTML report, and the document behind it as a standalone artifact.
+ *
+ * The report opens over `file://` with no server: relative paths, a classic script bundle, and the data
+ * as a script assigning a global rather than a fetched `.json`. It reaches no network at all — no CDN,
+ * no fonts, no analytics.
+ *
+ * # Layout
+ *
+ * The output path decides the layout, so there is no flag to keep in step with it:
+ *
+ * - a path ending in `.html` → everything inlined into that one file;
+ * - anything else → a directory with `index.html` and an `assets/` folder beside it.
+ *
+ * A multi-file report is cheaper to diff and lets a browser cache the assets; a single file is one
+ * artifact to attach to a CI build.
+ *
+ * # Activation
+ *
+ * ```
+ * # The default location, runtime/report/index.html
+ * ApplicationPlugins::with(new HtmlPlugin())
+ *
+ * # A single file, plus the document for external tooling
+ * ApplicationPlugins::with(new HtmlPlugin('build/report.html', 'build/report.json'))
+ * ```
+ *
+ * An inert copy — {@see inert()} — is part of the application defaults, so the `--log-html=<path>` and
+ * `--log-report=<path>` flags have something to activate without any change to `testo.php`. Instances are
+ * independent, and an instance configured in code ignores the flags entirely: as with the JUnit reporter,
+ * adding `--log-html` to a run whose config already registers this plugin yields two reports rather than a
+ * redirected one. Drop the default first to pin the report to a single path:
+ * `ApplicationPlugins::without(HtmlPlugin::class)->with(new HtmlPlugin('build/report'))`.
+ *
+ * @api
+ */
+final class HtmlPlugin implements PluginConfigurator
+{
+    /** Where a report goes when nothing says otherwise: under the project's runtime directory. */
+    public const DEFAULT_PATH = 'runtime/report';
+
+    /**
+     * Format id of the standalone document. Not plain `json`, which is what
+     * {@see \Testo\Output\Json\JsonPlugin} writes: both files are JSON and neither is the other's schema,
+     * so the id names the schema rather than the encoding.
+     */
+    private const DATA_FORMAT = 'testo-report';
+
+    /**
+     * The report is written from a `SessionFinished` listener, and so is the final summary. A lower
+     * priority runs later, which puts the write — and the announcement that follows it — after the
+     * summary: the reader gets the verdict without waiting for a large document to be serialized, and the
+     * path lands with every other artifact path a run states at its end.
+     */
+    private const LISTENER_PRIORITY = -100;
+
+    private readonly Recorder $recorder;
+    private readonly Writer $writer;
+
+    /** Destination of the page, or null when no page was asked for. */
+    private ?Path $htmlPath;
+
+    /** Destination of the standalone document, or null when it was not asked for. */
+    private ?Path $dataPath;
+
+    /**
+     * Single-shot guard, matching {@see \Testo\Output\JUnit\JUnitPlugin}: one instance is shared by every
+     * top-level run and by every nested {@see \Testo\Testing\Helper\TestRunner::runTest()} sub-run, and
+     * attaching twice would have an inner session overwrite the outer session's report.
+     */
+    private bool $configured = false;
+
+    private ?RunConfiguration $runConfiguration = null;
+
+    /** @var list<non-empty-string> */
+    private array $suiteNames = [];
+
+    /**
+     * @param non-empty-string|null $outputPath Directory to fill, or a `.html` file to write everything
+     *        into. Null means "no page unless `--log-html` asks for one".
+     * @param non-empty-string|null $dataPath Where to write the report document on its own. Null means
+     *        "not unless `--log-report` asks for it".
+     * @param non-empty-string $name Human-readable label carried by the announcement; what an IDE shows
+     *        on the button that opens the report.
+     * @param int<0, max> $messageLimit Bytes of channel output kept per test. Output is the one part of a
+     *        run with no natural size — a test that logs a loop can outweigh everything else in the
+     *        document — so it is capped, and the report states where it cut.
+     */
+    public function __construct(
+        ?string $outputPath = self::DEFAULT_PATH,
+        ?string $dataPath = null,
+        private readonly string $name = 'HTML report',
+        private readonly int $messageLimit = 65536,
+    ) {
+        $this->htmlPath = self::path($outputPath);
+        $this->dataPath = self::path($dataPath);
+        $this->recorder = new Recorder();
+        $this->writer = new Writer();
+    }
+
+    /**
+     * A copy that writes nothing until a CLI flag gives it a path.
+     *
+     * This is what the application defaults hold: a project that never mentions the reporter still gets
+     * `--log-html` and `--log-report`, and a project that never passes them gets no files.
+     */
+    public static function inert(): self
+    {
+        return new self(outputPath: null);
+    }
+
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        if ($this->configured) {
+            return;
+        }
+        $this->configured = true;
+
+        # Constructor paths win, the same way the JUnit reporter resolves its own: the flags are consulted
+        # only for an instance given no destination at all, which is how the inert default gets activated.
+        # A reporter configured in code owns both of its slots — a flag filling the empty one would add an
+        # output behind the config's back, and the inert default is already writing that file.
+        if ($this->htmlPath === null && $this->dataPath === null) {
+            $input = $container->get(ReportInput::class);
+            $this->htmlPath = self::path($input->htmlPath);
+            $this->dataPath = self::path($input->dataPath);
+
+            if ($this->htmlPath === null && $this->dataPath === null) {
+                return;
+            }
+        }
+
+        $this->runConfiguration = $container->get(RunConfiguration::class);
+        $this->suiteNames = self::suiteNames($container);
+
+        $listeners = $container->get(EventListenerCollector::class);
+        $this->recorder->configure($listeners);
+        $listeners->addListener(
+            SessionFinished::class,
+            $this->onSessionFinished(...),
+            self::LISTENER_PRIORITY,
+        );
+
+        # Registered after the listener that writes the files, so the late announcement follows the write.
+        $dispatcher = $container->get(EventDispatcherInterface::class);
+        foreach ($this->announced() as $info) {
+            $listeners->addListener(
+                SessionStarting::class,
+                static fn(): mixed => $dispatcher->dispatch(new ReportFileGenerating($info)),
+                self::LISTENER_PRIORITY,
+            );
+            $listeners->addListener(
+                SessionFinished::class,
+                static fn(): mixed => $dispatcher->dispatch(new ReportFileGenerated($info)),
+                self::LISTENER_PRIORITY,
+            );
+        }
+    }
+
+    private static function path(?string $path): ?Path
+    {
+        return $path === null || $path === '' ? null : Path::create($path);
+    }
+
+    /**
+     * Every configured suite, including the ones that ran nothing: a suite filtered down to zero tests
+     * leaves no trace in the results, and a report that omitted it would read as "no such suite".
+     *
+     * @return list<non-empty-string>
+     */
+    private static function suiteNames(Container $container): array
+    {
+        $names = [];
+        foreach ($container->get(ApplicationConfig::class)->suites as $suite) {
+            $names[] = $suite->name;
+        }
+
+        return $names;
+    }
+
+    /**
+     * The cards for whatever this instance was asked to write: the standalone document, the page, or both.
+     *
+     * @return list<ReportInfo>
+     */
+    private function announced(): array
+    {
+        $cards = [];
+        $this->dataPath === null or $cards[] = new ReportInfo(self::DATA_FORMAT, $this->name, $this->dataPath);
+        $this->htmlPath === null or $cards[] = new ReportInfo(
+            'html',
+            $this->name,
+            Writer::entryFile($this->htmlPath),
+        );
+
+        return $cards;
+    }
+
+    private function onSessionFinished(SessionFinished $event): void
+    {
+        $document = $this->build($event->result);
+
+        $this->dataPath === null or $this->writer->writeData($this->dataPath, $document);
+        $this->htmlPath === null or $this->writer->writeHtml($this->htmlPath, $document);
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function build(RunResult $result): array
+    {
+        return (new DocumentBuilder(
+            recorder: $this->recorder,
+            config: $this->runConfiguration ?? new RunConfiguration(),
+            messageLimit: $this->messageLimit,
+            suiteNames: $this->suiteNames,
+        ))->build($result);
+    }
+}

--- a/core/Output/Html/Internal/BenchMapper.php
+++ b/core/Output/Html/Internal/BenchMapper.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Testo\Bench\Dto\BenchResult;
+use Testo\Bench\Dto\CaseSet;
+use Testo\Bench\Dto\Line;
+use Testo\Bench\Dto\Report;
+use Testo\Bench\Dto\Report\Severity;
+use Testo\Bench\Dto\Snap;
+
+/**
+ * Benchmark measurements as data rather than as the ASCII table the terminal prints.
+ *
+ * A benchmark's structured result is the test's return value, so it needs no cooperation from the bench
+ * plugin beyond being installed — `testo/bench` stays a soft dependency, and a project without it never
+ * loads any of this.
+ *
+ * The numbers are taken from {@see Line}, the ranked view the plugin computes: it carries the relative
+ * difference against the fastest case, which is the comparison a reader actually makes, and the
+ * diagnostics that explain when a measurement should not be trusted. Times stay in microseconds, the
+ * unit the plugin measures in — converting here would only add a rounding step for the renderer to undo.
+ *
+ * @internal
+ */
+final class BenchMapper
+{
+    private function __construct() {}
+
+    /**
+     * True when the value is a benchmark result this mapper understands.
+     *
+     * @phpstan-assert-if-true BenchResult $value
+     */
+    public static function supports(mixed $value): bool
+    {
+        return \class_exists(BenchResult::class) && $value instanceof BenchResult;
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    public static function map(BenchResult $result): array
+    {
+        $iterations = $result->cases === [] ? 0 : \count($result->cases[0]->iterations);
+        $callsByCase = [];
+        /** @var CaseSet $case */
+        foreach ($result->cases as $case) {
+            /** @var list<Snap> $snaps */
+            $snaps = $case->iterations;
+            $callsByCase[$case->name] = $snaps === [] ? 0 : $snaps[0]->calls;
+        }
+
+        $cases = [];
+        $diagnostics = [];
+        /** @var Line $line */
+        foreach ($result->lines as $line) {
+            $cases[] = self::case($line, $callsByCase[$line->name] ?? 0);
+
+            /** @var Report $report */
+            foreach ($line->reports as $report) {
+                $diagnostics[] = [
+                    'case' => $line->name,
+                    'kind' => self::shortName($report::class),
+                    'severity' => self::severity($report->severity),
+                    'reason' => $report->reason,
+                    'advice' => $report->advice,
+                ];
+            }
+        }
+
+        return [
+            'iterations' => $iterations,
+            'cases' => $cases,
+            'diagnostics' => $diagnostics,
+        ];
+    }
+
+    /**
+     * @param int<0, max> $calls
+     * @return array<non-empty-string, mixed>
+     */
+    private static function case(Line $line, int $calls): array
+    {
+        return [
+            'name' => $line->name,
+            'place' => $line->place,
+            'calls' => $calls,
+            # Microseconds, as the bench plugin measures.
+            'mean' => $line->avg->value,
+            'median' => $line->med->value,
+            # Percent against the fastest case: 0.0 for the baseline, positive for slower.
+            'meanDiff' => $line->avg->diff,
+            # Standard deviation as a percentage of the mean.
+            'rstdev' => $line->rstdev,
+            # The same pair with outliers dropped, which is what a noisy environment leaves worth reading.
+            'filteredMean' => $line->favg->value,
+            'filteredRstdev' => $line->frstdev,
+            'rejected' => $line->rejected,
+        ];
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function severity(Severity $severity): string
+    {
+        return \strtolower($severity->name);
+    }
+
+    /**
+     * Class name without its namespace — `HighVariance` rather than the FQN, since the namespace says
+     * nothing a reader of the report needs.
+     *
+     * @param class-string $class
+     * @return non-empty-string
+     */
+    private static function shortName(string $class): string
+    {
+        $position = \strrpos($class, '\\');
+        /** @var non-empty-string */
+        return $position === false ? $class : \substr($class, $position + 1);
+    }
+}

--- a/core/Output/Html/Internal/Destination.php
+++ b/core/Output/Html/Internal/Destination.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Internal\Path;
+
+/**
+ * One place a run's report is written to: a path, what kind of output lands there, and the label an
+ * announcement carries for it.
+ *
+ * A run collects a set of these — from configured plugins and from the CLI flags — and writes the one
+ * document it built to each. {@see key()} dedups the set, so the same path named twice (a configured
+ * plugin and a flag pointing at it) is written and announced once.
+ *
+ * @internal
+ * @psalm-internal Testo\Output\Html
+ */
+final readonly class Destination
+{
+    /**
+     * @param non-empty-string $name Announcement label — what an IDE shows on the button.
+     */
+    public function __construct(
+        public Path $path,
+        public ReportKind $kind,
+        public string $name,
+    ) {}
+
+    /**
+     * Identity for deduplication: the same kind written to the same path is the same destination,
+     * whoever asked for it.
+     *
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+        return $this->kind->name . '|' . (string) $this->path;
+    }
+}

--- a/core/Output/Html/Internal/DocumentBuilder.php
+++ b/core/Output/Html/Internal/DocumentBuilder.php
@@ -42,7 +42,7 @@ use Testo\Retry;
  *
  * @internal
  */
-final class DocumentBuilder
+final readonly class DocumentBuilder
 {
     /**
      * Major version of the document. The renderer refuses a major it does not know rather than drawing a
@@ -50,7 +50,7 @@ final class DocumentBuilder
      */
     public const SCHEMA_VERSION = 1;
 
-    private readonly FailureMapper $failures;
+    private FailureMapper $failures;
 
     /**
      * @param int<0, max> $messageLimit Bytes of channel output kept per test; the rest is dropped and
@@ -61,10 +61,10 @@ final class DocumentBuilder
      *        from the report would read as "there is no such suite".
      */
     public function __construct(
-        private readonly Recorder $recorder,
-        private readonly RunConfiguration $config = new RunConfiguration(),
-        private readonly int $messageLimit = 65536,
-        private readonly array $suiteNames = [],
+        private Recorder $recorder,
+        private RunConfiguration $config = new RunConfiguration(),
+        private int $messageLimit = 65536,
+        private array $suiteNames = [],
     ) {
         $this->failures = new FailureMapper();
     }

--- a/core/Output/Html/Internal/DocumentBuilder.php
+++ b/core/Output/Html/Internal/DocumentBuilder.php
@@ -1,0 +1,726 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Testo\Application\Config\RunConfiguration;
+use Testo\Bench\Dto\BenchResult;
+use Testo\Core\Context\CaseResult;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteResult;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Log\Level;
+use Testo\Core\Log\Message;
+use Testo\Core\Log\MessageLog;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\Summary;
+use Testo\Common\Environment;
+use Testo\Common\Info;
+use Testo\Common\Reflection;
+use Testo\Data\MultipleResult;
+use Testo\Filter\Group;
+use Testo\Retry;
+
+/**
+ * Builds the report document — the whole run as one nested array, ready to be encoded.
+ *
+ * Everything is read off the finished {@see RunResult} and the {@see Recorder}, keyed by run id, so the
+ * order events arrived in during execution cannot change the outcome: concurrent tests land in the tree
+ * their results already form, not in the order they happened to finish.
+ *
+ * Determinism is a stated property of the document, which rules out two habits. Maps are emitted in a
+ * fixed order rather than in insertion order — status counts follow the {@see Status} enum, channel and
+ * metric names are sorted — because insertion order under concurrency is whatever the scheduler did.
+ * And nothing is stamped from the clock while building: every time in the document is an offset from the
+ * run start, taken from data recorded during the run.
+ *
+ * Plugin data is read where the plugin already leaves it, guarded by `class_exists` so a project that
+ * installed none of them still gets a report: data sets come from {@see MultipleResult}, assertion
+ * counts from {@see Summary::$metrics}, benchmarks from the test's own return value, and diffs from an
+ * assertion failure that carries both sides.
+ *
+ * @internal
+ */
+final class DocumentBuilder
+{
+    /**
+     * Major version of the document. The renderer refuses a major it does not know rather than drawing a
+     * half-broken page, so this changes only when a consumer would break.
+     */
+    public const SCHEMA_VERSION = 1;
+
+    private readonly FailureMapper $failures;
+
+    /**
+     * @param int<0, max> $messageLimit Bytes of channel output kept per test; the rest is dropped and
+     *        stated as truncated. Output is the one part of a run that has no natural size — a test that
+     *        logs a loop can outweigh every other field in the document put together.
+     * @param list<non-empty-string> $suiteNames Every configured suite, including the ones that ran
+     *        nothing: a suite filtered down to zero tests leaves no trace in the results, and its absence
+     *        from the report would read as "there is no such suite".
+     */
+    public function __construct(
+        private readonly Recorder $recorder,
+        private readonly RunConfiguration $config = new RunConfiguration(),
+        private readonly int $messageLimit = 65536,
+        private readonly array $suiteNames = [],
+    ) {
+        $this->failures = new FailureMapper();
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    public function build(RunResult $result): array
+    {
+        $channels = [];
+        $suites = [];
+        foreach ($result as $suite) {
+            $suites[] = $this->suite($suite, $channels);
+        }
+
+        return [
+            'schemaVersion' => self::SCHEMA_VERSION,
+            'generator' => ['name' => 'testo/testo', 'version' => Info::version()],
+            'run' => $this->run($result),
+            'environment' => $this->environment(),
+            'channels' => self::channels($channels),
+            'levels' => self::levels(),
+            'suites' => $suites,
+        ];
+    }
+
+    /**
+     * Arguments of one call, named after the parameters they were bound to.
+     *
+     * @return list<array{name: string, type: string, value: string}>
+     */
+    private static function arguments(TestResult $result): array
+    {
+        $parameters = $result->info->testDefinition->reflection->getParameters();
+
+        $arguments = [];
+        $position = 0;
+        foreach ($result->info->arguments as $key => $value) {
+            $name = \is_string($key) ? $key : ($parameters[$position]->name ?? (string) $position);
+            ++$position;
+
+            $arguments[] = [
+                'name' => $name,
+                'type' => ValuePrinter::type($value),
+                'value' => ValuePrinter::print($value),
+            ];
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private static function message(Message $message, float $startedAt): array
+    {
+        $data = [
+            # Relative to the run start: an absolute timestamp would make two runs of the same code
+            # produce different documents, and a reader compares messages to each other anyway.
+            'time' => $message->time - $startedAt,
+            'channel' => $message->channel,
+            'level' => $message->level->value,
+            'content' => $message->content,
+        ];
+
+        $message->context === [] or $data['context'] = self::scalarMap($message->context);
+
+        return $data;
+    }
+
+    /**
+     * Channels the run wrote to, with how many messages each carried. Names only — how a channel looks
+     * is the renderer's business, and a document that pinned colours would freeze them into every
+     * report ever written.
+     *
+     * @param array<string, int> $counts
+     * @return list<array{name: string, messages: int}>
+     */
+    private static function channels(array $counts): array
+    {
+        \ksort($counts, \SORT_STRING);
+
+        $channels = [];
+        foreach ($counts as $name => $messages) {
+            $channels[] = ['name' => $name, 'messages' => $messages];
+        }
+
+        return $channels;
+    }
+
+    /**
+     * Severity levels, most severe first — the order a level filter offers them in.
+     *
+     * @return list<string>
+     */
+    private static function levels(): array
+    {
+        return \array_map(static fn(Level $level): string => $level->value, Level::cases());
+    }
+
+    /**
+     * Test counts, every status present including the zeros, in enum order.
+     *
+     * Insertion order would be whatever order tests finished in, which concurrency makes unstable; the
+     * enum order is the same in every report. The zeros are kept on purpose — a filter that offers the
+     * full vocabulary needs to know a status exists and counted nothing.
+     *
+     * @return array<non-empty-string, mixed>
+     */
+    private static function summary(Summary $summary): array
+    {
+        $counts = [];
+        foreach (Status::cases() as $status) {
+            $counts[self::status($status)] = $summary->count($status);
+        }
+
+        return [
+            'total' => $summary->total(),
+            'counts' => $counts,
+            'metrics' => self::metrics($summary),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private static function metrics(Summary $summary): array
+    {
+        $metrics = $summary->metrics;
+        \ksort($metrics, \SORT_STRING);
+
+        return $metrics;
+    }
+
+    /**
+     * The description as the run ended up with it, which is not always the one in the PHPDoc: it is
+     * computed in the pipeline and a plugin may replace it, so the attribute wins over the source.
+     */
+    private static function description(TestResult $result): ?string
+    {
+        $description = $result->getAttribute('description');
+        \is_string($description) && $description !== '' or $description = null;
+
+        $description ??= $result->info->testDefinition->getDescription();
+
+        return $description === '' ? null : $description;
+    }
+
+    /**
+     * Why a test is not simply passed or failed — the message of a skip, a cancel or an abort, which is
+     * the only place that reason exists.
+     */
+    private static function statusReason(TestResult $result): ?string
+    {
+        if ($result->failure === null || $result->status->isFailure()) {
+            return null;
+        }
+
+        $message = $result->failure->getMessage();
+
+        return $message === '' ? null : $message;
+    }
+
+    /**
+     * Groups a test belongs to — the union of what the method, its class, the parents and the traits
+     * declare, which is the same set `--group` selects on.
+     *
+     * Read through reflection rather than off the result: {@see Group} is consumed by the filter at
+     * discovery time and never lands in a test's attributes, so there is nowhere else to read it from.
+     * Sorted, because the union's order follows the traversal and says nothing.
+     *
+     * @return list<string>
+     */
+    private static function groups(TestResult $result): array
+    {
+        if (!\class_exists(Group::class)) {
+            return [];
+        }
+
+        $info = $result->info;
+        $reflections = [$info->testDefinition->reflection];
+        $class = $info->caseInfo->definition->reflection;
+        $class === null or $reflections[] = $class;
+
+        $groups = [];
+        foreach ($reflections as $reflection) {
+            $attributes = $reflection instanceof \ReflectionClass
+                ? Reflection::fetchClassAttributes($reflection, attributeClass: Group::class)
+                : Reflection::fetchFunctionAttributes($reflection, attributeClass: Group::class);
+
+            foreach ($attributes as $attribute) {
+                foreach ($attribute->newInstance()->names as $name) {
+                    $name === '' or $groups[$name] = true;
+                }
+            }
+        }
+
+        $groups = \array_keys($groups);
+        \sort($groups, \SORT_STRING);
+
+        return $groups;
+    }
+
+    /**
+     * @return array{maxAttempts: int, markFlaky: bool}|null
+     */
+    private static function retryPolicy(TestResult $result): ?array
+    {
+        if (!\class_exists(Retry::class)) {
+            return null;
+        }
+
+        foreach (self::attributeList($result, Retry::class) as $policy) {
+            if ($policy instanceof Retry) {
+                return ['maxAttempts' => $policy->maxAttempts, 'markFlaky' => $policy->markFlaky];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Attributes of one class as the pipeline grouped them: a list per attribute class, since an
+     * attribute may repeat on a test.
+     *
+     * @param class-string|non-empty-string $class
+     * @return list<object>
+     */
+    private static function attributeList(TestResult $result, string $class): array
+    {
+        /** @var mixed $attributes */
+        $attributes = $result->info->getAttribute($class);
+
+        if (\is_object($attributes)) {
+            return [$attributes];
+        }
+
+        if (!\is_array($attributes)) {
+            return [];
+        }
+
+        return \array_values(\array_filter($attributes, \is_object(...)));
+    }
+
+    /**
+     * Anything that cannot survive JSON as itself, stated as a label instead — a report describes the
+     * input it was given, and an unserializable value still has a readable form.
+     *
+     * @param array<array-key, mixed> $values
+     * @return array<string, mixed>
+     */
+    private static function scalarMap(array $values): array
+    {
+        $result = [];
+        foreach ($values as $key => $value) {
+            $result[(string) $key] = match (true) {
+                \is_scalar($value), $value === null => $value,
+                \is_array($value) => \array_map(
+                    static fn(mixed $item): mixed => \is_scalar($item) || $item === null
+                        ? $item
+                        : ValuePrinter::print($item),
+                    \array_values($value),
+                ),
+                default => ValuePrinter::print($value),
+            };
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function status(Status $status): string
+    {
+        return \strtolower($status->name);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function timestamp(float $microtime): string
+    {
+        /** @var non-empty-string */
+        return \date(\DATE_ATOM, (int) $microtime);
+    }
+
+    /**
+     * Total wall-clock the given `[start, end]` intervals cover, overlaps counted once.
+     *
+     * @param list<array{float, float}> $intervals
+     */
+    private static function union(array $intervals): float
+    {
+        if ($intervals === []) {
+            return 0.0;
+        }
+
+        \usort($intervals, static fn(array $a, array $b): int => $a[0] <=> $b[0]);
+
+        $total = 0.0;
+        [$start, $end] = $intervals[0];
+        foreach ($intervals as [$s, $e]) {
+            if ($s > $end) {
+                # A gap: close the run in progress and open a new one.
+                $total += $end - $start;
+                $start = $s;
+                $end = $e;
+            } elseif ($e > $end) {
+                $end = $e;
+            }
+        }
+
+        return $total + ($end - $start);
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function run(RunResult $result): array
+    {
+        $phases = [];
+        foreach ($result->timing->phases() as $name => $duration) {
+            $phases[] = ['name' => $name, 'duration' => $duration];
+        }
+
+        # Wall-clock during which at least one test body was running — the union of the intervals the
+        # timeline draws, overlaps counted once. Two things fall out of it that summed time alone cannot
+        # tell apart: pipeline overhead (`tests` phase minus execution — framework work around and
+        # between the bodies), and the concurrency boost (declared work over the wall it truly took).
+        $intervals = [];
+        $work = 0.0;
+        foreach ($result as $suite) {
+            foreach ($suite as $case) {
+                foreach ($case as $test) {
+                    $offset = $this->recorder->offsetOf($test->info->identity);
+                    if ($offset === null) {
+                        continue;
+                    }
+                    $duration = $test->summary->duration;
+                    $intervals[] = [$offset, $offset + $duration];
+                    $work += $duration;
+                }
+            }
+        }
+
+        $execution = self::union($intervals);
+
+        return [
+            'status' => self::status($result->status),
+            'startedAt' => self::timestamp($this->recorder->startedAt()),
+            'duration' => $result->duration(),
+            # Summed test time, which exceeds the wall clock when tests ran concurrently. The report says
+            # so rather than presenting the difference as an inconsistency.
+            'testDuration' => $result->summary->duration,
+            'execution' => $execution,
+            'overhead' => \max(0.0, $result->timing->tests - $execution),
+            'boost' => $execution > 0.0 ? $work / $execution : null,
+            'phases' => $phases,
+            'summary' => self::summary($result->summary),
+        ];
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function environment(): array
+    {
+        return [
+            'php' => Environment::getPhpVersion(),
+            'sapi' => \PHP_SAPI,
+            'testo' => Info::version(),
+            'os' => Environment::getOs(),
+            'cpu' => Environment::getCpu(),
+            'cwd' => \getcwd() ?: '',
+            'extensions' => [
+                'xdebug' => Environment::hasXDebug() ? Environment::getXDebugVersion() : null,
+                'pcov' => \extension_loaded('pcov') ? (string) \phpversion('pcov') : null,
+                'opcache' => Environment::isOpCacheEnabled()
+                    ? (Environment::isJitEnabled() ? 'enabled with JIT' : 'enabled')
+                    : null,
+            ],
+            'config' => [
+                'file' => (string) $this->config->configFile,
+                'suites' => $this->suiteNames,
+                # The effective input, minus the defaults nobody asked for. Environment variables are
+                # deliberately absent: a report gets committed and shared, tokens must not travel with it.
+                'options' => self::scalarMap($this->config->givenOptions()),
+                'arguments' => self::scalarMap($this->config->arguments),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, int> $channels Message count per channel, accumulated across the walk.
+     * @return array<non-empty-string, mixed>
+     */
+    private function suite(SuiteResult $result, array &$channels): array
+    {
+        $cases = [];
+        $name = null;
+        foreach ($result as $case) {
+            $cases[] = $this->case($case, $channels, $name);
+        }
+
+        return [
+            'id' => $name ?? '(empty)',
+            'name' => $name ?? '(empty)',
+            'status' => self::status($result->status),
+            'duration' => $result->summary->duration,
+            'summary' => self::summary($result->summary),
+            'cases' => $cases,
+        ];
+    }
+
+    /**
+     * @param array<string, int> $channels
+     * @param non-empty-string|null $suiteName Filled in from the first test met — a suite result carries
+     *        no name of its own, and its tests' addresses are where the name actually lives.
+     * @return array<non-empty-string, mixed>
+     */
+    private function case(CaseResult $result, array &$channels, ?string &$suiteName): array
+    {
+        $tests = [];
+        $name = null;
+        $file = null;
+        $type = null;
+
+        foreach ($result as $test) {
+            $identity = $test->info->identity;
+            $suiteName ??= $identity->suite;
+            # The class the case groups, or the file when there is no class — a case of free functions
+            # groups a file rather than a type. Not `CaseInfo::$name`, which carries a `[type]` suffix
+            # meant for a terminal header: the type is already a field of its own here.
+            $name ??= $identity->case ?? (string) $identity->file;
+            $file ??= (string) $identity->file;
+            $type ??= $identity->type;
+
+            $tests[] = $this->test($test, $channels);
+        }
+
+        return [
+            'id' => ($suiteName ?? '') . '::' . ($name ?? '(empty)'),
+            'name' => $name ?? '(empty)',
+            'file' => $file ?? '',
+            'type' => $type ?? 'test',
+            'status' => self::status($result->status),
+            'duration' => $result->summary->duration,
+            'tests' => $tests,
+        ];
+    }
+
+    /**
+     * @param array<string, int> $channels
+     * @return array<non-empty-string, mixed>
+     */
+    private function test(TestResult $result, array &$channels): array
+    {
+        $info = $result->info;
+        $identity = $info->identity;
+        $reflection = $info->testDefinition->reflection;
+
+        $data = [
+            'id' => $identity->suite . '::' . $identity->fqn(),
+            # The exact string `--filter` takes back, so a reader can rerun what they are looking at.
+            'filter' => $identity->fqn(),
+            'name' => $info->name,
+            'description' => self::description($result),
+            'type' => $identity->type,
+            'status' => self::status($result->status),
+            'groups' => self::groups($result),
+            'file' => (string) $identity->file,
+            'line' => $reflection->getStartLine() === false ? null : $reflection->getStartLine(),
+            'startedAt' => $this->recorder->offsetOf($identity),
+            'duration' => $result->summary->duration,
+            'metrics' => self::metrics($result->summary),
+        ];
+
+        $reason = self::statusReason($result);
+        $reason === null or $data['statusReason'] = $reason;
+
+        if ($result->failure !== null) {
+            $data['failure'] = $this->failures->map($result->failure, $reflection);
+        }
+
+        $attempts = $this->attempts($result, $channels);
+        $attempts === null or $data['attempts'] = $attempts;
+
+        $policy = self::retryPolicy($result);
+        $policy === null or $data['retryPolicy'] = $policy;
+
+        $dataSets = $this->dataSets($result, $channels);
+        $dataSets === null or $data['dataSets'] = $dataSets;
+
+        if (BenchMapper::supports($result->result)) {
+            /** @var BenchResult $bench */
+            $bench = $result->result;
+            $data['bench'] = BenchMapper::map($bench);
+        }
+
+        $output = $this->messages($result->messages, $channels);
+        $output['messages'] === [] or $data['messages'] = $output['messages'];
+        $output['truncated'] === null or $data['truncated'] = ['messages' => $output['truncated']];
+
+        return $data;
+    }
+
+    /**
+     * Every attempt of a retried test, oldest first, with the kept one last.
+     *
+     * Null — rather than a single-entry list — when the test ran once: an attempt count is only worth
+     * showing where there was more than one, and a list of one would put an "attempts" section on every
+     * test in the report.
+     *
+     * @param array<string, int> $channels
+     * @return list<array<non-empty-string, mixed>>|null
+     */
+    private function attempts(TestResult $result, array &$channels): ?array
+    {
+        $discarded = $this->recorder->discardedAttemptsOf($result->info->identity);
+        if ($discarded === []) {
+            return null;
+        }
+
+        $attempts = [];
+        foreach ($discarded as $attempt) {
+            $attempts[] = $this->attempt($attempt['number'], $attempt['result'], false, $channels);
+        }
+
+        $attempts[] = $this->attempt(\count($attempts) + 1, $result, true, $channels);
+
+        return $attempts;
+    }
+
+    /**
+     * @param int<1, max> $number
+     * @param array<string, int> $channels
+     * @return array<non-empty-string, mixed>
+     */
+    private function attempt(int $number, TestResult $result, bool $kept, array &$channels): array
+    {
+        $data = [
+            'number' => $number,
+            'status' => self::status($result->status),
+            'duration' => $result->summary->duration,
+            'kept' => $kept,
+        ];
+
+        if ($result->failure !== null) {
+            $data['failure'] = $this->failures->map($result->failure, $result->info->testDefinition->reflection);
+        }
+
+        # A discarded attempt's own output went into a dropped scope, so it usually has none; when it does,
+        # it belongs to the attempt rather than to the test that eventually passed.
+        $output = $kept ? ['messages' => [], 'truncated' => null] : $this->messages($result->messages, $channels);
+        $output['messages'] === [] or $data['messages'] = $output['messages'];
+
+        return $data;
+    }
+
+    /**
+     * Data sets of one test, each with the arguments it was called with.
+     *
+     * @param array<string, int> $channels
+     * @return list<array<non-empty-string, mixed>>|null
+     */
+    private function dataSets(TestResult $result, array &$channels): ?array
+    {
+        if (!\class_exists(MultipleResult::class)) {
+            return null;
+        }
+
+        $multiple = $result->getAttribute(MultipleResult::class);
+        if (!$multiple instanceof MultipleResult) {
+            return null;
+        }
+
+        $sets = [];
+        foreach ($multiple->results as $set) {
+            $identity = $set->info->identity;
+            $coordinates = $this->recorder->dataSetOf($identity);
+
+            $data = [
+                'providerIndex' => $identity->dataProvider,
+                'index' => $identity->dataSet ?? 0,
+                # Addressed by index, labelled by key: provider keys are free to repeat, so the key is a
+                # label and never an address.
+                'key' => (string) ($coordinates['key'] ?? ($identity->dataSet ?? 0)),
+                'status' => self::status($set->status),
+                'duration' => $set->summary->duration,
+                'metrics' => self::metrics($set->summary),
+                'arguments' => self::arguments($set),
+            ];
+
+            if ($set->failure !== null) {
+                $data['failure'] = $this->failures->map($set->failure, $set->info->testDefinition->reflection);
+            }
+
+            if (BenchMapper::supports($set->result)) {
+                /** @var BenchResult $bench */
+                $bench = $set->result;
+                $data['bench'] = BenchMapper::map($bench);
+            }
+
+            $output = $this->messages($set->messages, $channels);
+            $output['messages'] === [] or $data['messages'] = $output['messages'];
+
+            $sets[] = $data;
+        }
+
+        return $sets;
+    }
+
+    /**
+     * Channel output of one test, capped at {@see $messageLimit} bytes.
+     *
+     * @param array<string, int> $channels
+     * @return array{
+     *     messages: list<array<non-empty-string, mixed>>,
+     *     truncated: array{shown: int, total: int, bytes: int, limit: int}|null
+     * }
+     */
+    private function messages(MessageLog $log, array &$channels): array
+    {
+        $messages = [];
+        $bytes = 0;
+        $total = \count($log);
+        $truncated = false;
+        $startedAt = $this->recorder->startedAt();
+
+        foreach ($log as $message) {
+            $channels[$message->channel] = ($channels[$message->channel] ?? 0) + 1;
+            $bytes += \strlen($message->content);
+
+            if ($truncated) {
+                continue;
+            }
+
+            if ($bytes > $this->messageLimit) {
+                $truncated = true;
+                continue;
+            }
+
+            $messages[] = self::message($message, $startedAt);
+        }
+
+        return [
+            'messages' => $messages,
+            'truncated' => $truncated
+                ? [
+                    'shown' => \count($messages),
+                    'total' => $total,
+                    'bytes' => $bytes,
+                    'limit' => $this->messageLimit,
+                ]
+                : null,
+        ];
+    }
+}

--- a/core/Output/Html/Internal/FailureMapper.php
+++ b/core/Output/Html/Internal/FailureMapper.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Testo\Assert\State\Assertion\ComparisonFailure;
+use Testo\Output\Rendering\Diff\DiffOp;
+use Testo\Output\Rendering\Diff\MyersDiffer;
+use Testo\Output\Rendering\StackTrace;
+
+/**
+ * A throwable as the report shows it: what failed, where, what the line looked like, and — when the
+ * failure knows both sides of a comparison — the diff between them.
+ *
+ * The `previous` chain is flattened into `causedBy` with locations only: the outermost trace already
+ * covers the call path, and repeating it per link would multiply the document's size for nothing.
+ *
+ * Diffs come from {@see ComparisonFailure}, which lives in `testo/assert` — a soft dependency, since a
+ * project can assert with anything. Without it, or with a failure of another kind, the report keeps the
+ * message and the trace and shows no diff, rather than inventing one.
+ *
+ * @internal
+ */
+final class FailureMapper
+{
+    /**
+     * Longest file the source line is read out of. A generated fixture can be megabytes; a report is
+     * not the place to page one in.
+     */
+    private const MAX_SOURCE_FILE_SIZE = 2 * 1024 * 1024;
+
+    /**
+     * Source lines already read, keyed by file. A failing assertion in a loop points at one line from
+     * many frames, and the file is worth reading once.
+     *
+     * @var array<string, list<string>|null>
+     */
+    private array $sources = [];
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    public function map(\Throwable $failure, ?\ReflectionFunctionAbstract $boundary = null): array
+    {
+        $file = $failure->getFile();
+        $line = $failure->getLine();
+
+        $data = [
+            'class' => $failure::class,
+            'message' => $failure->getMessage(),
+            'file' => $file,
+            'line' => $line,
+        ];
+
+        $source = $this->sourceLine($file, $line);
+        $source === null or $data['sourceLine'] = $source;
+
+        $diff = self::diff($failure);
+        $diff === null or $data['diff'] = $diff;
+
+        $data['trace'] = self::trace($failure, $boundary);
+
+        $causedBy = self::causedBy($failure);
+        $causedBy === [] or $data['causedBy'] = $causedBy;
+
+        return $data;
+    }
+
+    /**
+     * The two sides of a comparison and the line-by-line edit script between them.
+     *
+     * @return array{expected: string, actual: string, lines: list<array{op: string, text: string}>}|null
+     */
+    private static function diff(\Throwable $failure): ?array
+    {
+        if (!\class_exists(ComparisonFailure::class) || !$failure instanceof ComparisonFailure) {
+            return null;
+        }
+
+        $expected = $failure->getExpectedAsString();
+        $actual = $failure->getActualAsString();
+
+        $lines = [];
+        foreach ((new MyersDiffer())->diff($expected, $actual) as $diffLine) {
+            $lines[] = [
+                'op' => match ($diffLine->op) {
+                    DiffOp::Add => 'add',
+                    DiffOp::Remove => 'del',
+                    DiffOp::Context => 'ctx',
+                },
+                'text' => $diffLine->line,
+            ];
+        }
+
+        return ['expected' => $expected, 'actual' => $actual, 'lines' => $lines];
+    }
+
+    /**
+     * Frames trimmed at the test function, the same way every other Testo reporter trims them: below the
+     * test is the runner's own pipeline, which is noise to anyone reading the failure.
+     *
+     * @return list<array{file: string, line: int|null, call: string}>
+     */
+    private static function trace(\Throwable $failure, ?\ReflectionFunctionAbstract $boundary): array
+    {
+        $frames = [];
+        foreach (StackTrace::cutStackTrace($failure->getTrace(), $boundary) as $frame) {
+            /** @var array{file?: string, line?: int, class?: string, type?: string, function?: string} $frame */
+            $class = $frame['class'] ?? '';
+            $function = $frame['function'] ?? '';
+
+            $frames[] = [
+                'file' => $frame['file'] ?? '[internal function]',
+                'line' => $frame['line'] ?? null,
+                'call' => $class === ''
+                    ? "{$function}()"
+                    : $class . ($frame['type'] ?? '::') . "{$function}()",
+            ];
+        }
+
+        return $frames;
+    }
+
+    /**
+     * @return list<array{class: class-string, message: string, file: string, line: int}>
+     */
+    private static function causedBy(\Throwable $failure): array
+    {
+        $chain = [];
+        $current = $failure->getPrevious();
+        while ($current !== null) {
+            $chain[] = [
+                'class' => $current::class,
+                'message' => $current->getMessage(),
+                'file' => $current->getFile(),
+                'line' => $current->getLine(),
+            ];
+            $current = $current->getPrevious();
+        }
+
+        return $chain;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private static function readSource(string $file): ?array
+    {
+        if (!\is_file($file) || !\is_readable($file)) {
+            return null;
+        }
+
+        $size = \filesize($file);
+        if ($size === false || $size > self::MAX_SOURCE_FILE_SIZE) {
+            return null;
+        }
+
+        $lines = \file($file, \FILE_IGNORE_NEW_LINES);
+
+        return $lines === false ? null : $lines;
+    }
+
+    /**
+     * The source line the failure points at, trimmed of indentation, or null when the file cannot be
+     * read — a failure inside an eval, a file already deleted, a stream the report has no business
+     * paging in.
+     */
+    private function sourceLine(string $file, int $line): ?string
+    {
+        if ($line < 1) {
+            return null;
+        }
+
+        if (!\array_key_exists($file, $this->sources)) {
+            $this->sources[$file] = self::readSource($file);
+        }
+
+        $source = $this->sources[$file];
+        if ($source === null) {
+            return null;
+        }
+
+        $text = \trim($source[$line - 1] ?? '');
+
+        return $text === '' ? null : $text;
+    }
+}

--- a/core/Output/Html/Internal/HtmlReportSink.php
+++ b/core/Output/Html/Internal/HtmlReportSink.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Internal\Container\Container;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\RunConfiguration;
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Report\ReportInfo;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Report\ReportFileGenerated;
+use Testo\Event\Report\ReportFileGenerating;
+
+/**
+ * Per-run collector that turns however many {@see \Testo\Output\Html\HtmlPlugin} instances are active
+ * into a single report producer.
+ *
+ * Several instances can be live at once — most commonly the inert shadow default (which serves the
+ * `--log-html` / `--log-report` flags) alongside a plugin declared in `testo.php`. Each contributes its
+ * destinations here; the set is deduplicated, so the same path named by a configured plugin and by a
+ * flag is written once. One {@see Recorder} feeds every destination and the document is built exactly
+ * once — the report is a view over one run's data, not per-destination data — and the widest requested
+ * `messageLimit` wins, since a single document cannot truncate two ways.
+ *
+ * The write runs from a {@see SessionFinished} listener at a low priority, after the run summary, so the
+ * verdict prints before a large document is serialized and every artifact path a run states lands
+ * together at the end.
+ *
+ * @internal
+ * @psalm-internal Testo\Output\Html
+ */
+final class HtmlReportSink
+{
+    /**
+     * Format id of the standalone document. Not plain `json`, which is what
+     * {@see \Testo\Output\Json\JsonPlugin} writes: both files are JSON and neither is the other's schema,
+     * so the id names the schema rather than the encoding.
+     */
+    public const DATA_FORMAT = 'testo-report';
+
+    /** Lower runs later — see the class docblock. */
+    private const LISTENER_PRIORITY = -100;
+
+    private readonly Recorder $recorder;
+    private readonly Writer $writer;
+
+    /**
+     * Captured here, not re-fetched when the events fire: the container hands out per-scope dispatcher
+     * clones, and the one that reaches the app-scope renderers (which turn a `ReportFileGenerated` into a
+     * printed line) is the one live at configuration time — the same reason the JUnit reporter captures it.
+     */
+    private readonly EventDispatcherInterface $dispatcher;
+
+    private readonly RunConfiguration $config;
+
+    /** @var list<non-empty-string> */
+    private readonly array $suiteNames;
+
+    /** @var array<non-empty-string, Destination> Keyed by {@see Destination::key()} to dedup. */
+    private array $destinations = [];
+
+    /** @var int<0, max> Widest truncation limit any contributor asked for. */
+    private int $messageLimit = 0;
+
+    public function __construct(Container $container)
+    {
+        $this->recorder = new Recorder();
+        $this->writer = new Writer();
+        $this->dispatcher = $container->get(EventDispatcherInterface::class);
+        $this->config = $container->get(RunConfiguration::class);
+        $this->suiteNames = self::suiteNames($container);
+
+        $listeners = $container->get(EventListenerCollector::class);
+        $this->recorder->configure($listeners);
+
+        # The write is registered before the announcement so the late `Generated` follows it; both sit at
+        # the same low priority, after the summary.
+        $listeners->addListener(SessionFinished::class, $this->onSessionFinished(...), self::LISTENER_PRIORITY);
+        $listeners->addListener(SessionStarting::class, $this->onSessionStarting(...), self::LISTENER_PRIORITY);
+    }
+
+    /**
+     * Adds a plugin's destinations to the run's set and widens the truncation limit to fit.
+     *
+     * @param int<0, max> $messageLimit
+     */
+    public function contribute(int $messageLimit, Destination ...$destinations): void
+    {
+        $messageLimit > $this->messageLimit and $this->messageLimit = $messageLimit;
+
+        foreach ($destinations as $destination) {
+            $this->destinations[$destination->key()] = $destination;
+        }
+    }
+
+    /**
+     * Every configured suite, including the ones that ran nothing: a suite filtered down to zero tests
+     * leaves no trace in the results, and a report that omitted it would read as "no such suite".
+     *
+     * @return list<non-empty-string>
+     */
+    private static function suiteNames(Container $container): array
+    {
+        $names = [];
+        foreach ($container->get(ApplicationConfig::class)->suites as $suite) {
+            $names[] = $suite->name;
+        }
+
+        return $names;
+    }
+
+    /**
+     * Promises every destination up front, while the run's output is still open — a `testoReport` service
+     * message after the last `testSuiteFinished` has no node in an IDE's run tree to attach to.
+     */
+    private function onSessionStarting(): void
+    {
+        foreach ($this->destinations as $destination) {
+            $this->dispatcher->dispatch(new ReportFileGenerating($this->info($destination)));
+        }
+    }
+
+    private function onSessionFinished(SessionFinished $event): void
+    {
+        if ($this->destinations === []) {
+            return;
+        }
+
+        $document = $this->build($event->result);
+
+        foreach ($this->destinations as $destination) {
+            $destination->kind === ReportKind::Html
+                ? $this->writer->writeHtml($destination->path, $document)
+                : $this->writer->writeData($destination->path, $document);
+
+            $this->dispatcher->dispatch(new ReportFileGenerated($this->info($destination)));
+        }
+    }
+
+    private function info(Destination $destination): ReportInfo
+    {
+        return $destination->kind === ReportKind::Html
+            ? new ReportInfo('html', $destination->name, Writer::entryFile($destination->path))
+            : new ReportInfo(self::DATA_FORMAT, $destination->name, $destination->path);
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function build(RunResult $result): array
+    {
+        return (new DocumentBuilder(
+            recorder: $this->recorder,
+            config: $this->config,
+            messageLimit: $this->messageLimit,
+            suiteNames: $this->suiteNames,
+        ))->build($result);
+    }
+}

--- a/core/Output/Html/Internal/Json.php
+++ b/core/Output/Html/Internal/Json.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+/**
+ * Encodes the report document, in the two forms it is consumed in.
+ *
+ * Both are deterministic: the document arrives with its order already fixed, and nothing here sorts,
+ * stamps or reorders anything. Floats keep their fraction so a duration of `1.0` does not turn into `1`
+ * and back, which would make two encodings of one run differ.
+ *
+ * Invalid UTF-8 is substituted rather than fatal. Message contents are raw bytes from user code — binary
+ * output, a non-UTF-8 fixture — and a run that produced one bad byte must still get its report.
+ *
+ * @internal
+ */
+final class Json
+{
+    private const COMMON = \JSON_UNESCAPED_UNICODE
+        | \JSON_INVALID_UTF8_SUBSTITUTE
+        | \JSON_PRESERVE_ZERO_FRACTION
+        | \JSON_THROW_ON_ERROR;
+
+    private function __construct() {}
+
+    /**
+     * The standalone data artifact: pretty-printed and with readable slashes, because a human and a
+     * `git diff` are among its consumers.
+     *
+     * @param array<non-empty-string, mixed> $document
+     */
+    public static function artifact(array $document): string
+    {
+        return \json_encode($document, self::COMMON | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES) . "\n";
+    }
+
+    /**
+     * The same document as a script that assigns a global.
+     *
+     * Compact, and with slashes escaped on purpose: a message containing `</script>` would otherwise
+     * close the tag it is embedded in and hand the rest of the report to the HTML parser. `<\/script>`
+     * is the same string to a JSON reader and inert to an HTML one.
+     *
+     * @param array<non-empty-string, mixed> $document
+     */
+    public static function script(array $document): string
+    {
+        return 'window.TESTO_REPORT = ' . \json_encode($document, self::COMMON) . ";\n";
+    }
+}

--- a/core/Output/Html/Internal/Recorder.php
+++ b/core/Output/Html/Internal/Recorder.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\Identity;
+use Testo\Core\Context\TestResult;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Test\TestDataSetStarting;
+use Testo\Event\Test\TestPipelineStarting;
+use Testo\Event\Test\TestRetrying;
+
+/**
+ * The part of a run that its results do not keep.
+ *
+ * A {@see \Testo\Core\Context\RunResult} says what happened; three things it does not say are needed to
+ * describe a run in full:
+ *
+ * - **when** the run and each test began — durations alone cannot draw a timeline, and cannot show that
+ *   concurrent tests overlapped;
+ * - the **label** of a data set — `TestIdentity` addresses a data set by index, on purpose, because
+ *   provider keys are free to repeat, so the key stays on the event;
+ * - the **discarded attempts** of a retried test — the retry interceptor returns the last attempt and
+ *   drops the rest, leaving only a breadcrumb in the `retry` channel.
+ *
+ * Everything is keyed by {@see Identity::$runtimeId}: one number per in-flight run, shared by a test's
+ * retries (they re-attempt one run) and distinct for every data set, which is exactly the granularity
+ * wanted here. Keying by name instead would merge two suites that include the same file.
+ *
+ * Recording during the run and reading afterwards is the one thing that cannot be derived from the
+ * finished result — so the order events arrive in must not leak into the document. It does not: entries
+ * are stored per run id and read back by the tree walk, never appended to a shared list.
+ *
+ * @internal
+ */
+final class Recorder
+{
+    /** Wall-clock start of the run, as {@see \microtime()} returns it; null before the session starts. */
+    private ?float $startedAt = null;
+
+    /**
+     * Offset from the run start at which each test began, keyed by run id.
+     *
+     * @var array<int, float>
+     */
+    private array $starts = [];
+
+    /**
+     * Data-set coordinates and label, keyed by the data set's own run id.
+     *
+     * @var array<int, array{key: string|int, provider: int|null, index: int}>
+     */
+    private array $dataSets = [];
+
+    /**
+     * Attempts a retry discarded, in the order they ran, keyed by the test's run id.
+     *
+     * @var array<int, list<array{number: int<1, max>, result: TestResult}>>
+     */
+    private array $attempts = [];
+
+    public function configure(EventListenerCollector $listeners): void
+    {
+        $listeners->addListener(SessionStarting::class, $this->onSessionStarting(...));
+        $listeners->addListener(TestPipelineStarting::class, $this->onTestStarting(...));
+        $listeners->addListener(TestDataSetStarting::class, $this->onDataSetStarting(...));
+        $listeners->addListener(TestRetrying::class, $this->onTestRetrying(...));
+    }
+
+    /**
+     * Wall-clock start of the run — the origin every offset in the document is measured from.
+     *
+     * Falls back to now for a reporter that was configured after the session started, so timings degrade
+     * to zero-length rather than turning into nonsense far in the past.
+     */
+    public function startedAt(): float
+    {
+        return $this->startedAt ??= \microtime(true);
+    }
+
+    /**
+     * Seconds from the run start to the moment this test began, or null when the test never announced a
+     * start — a case the finished result cannot fill in, so the timeline leaves the row out.
+     */
+    public function offsetOf(Identity $identity): ?float
+    {
+        return $this->starts[$identity->runtimeId] ?? null;
+    }
+
+    /**
+     * @return array{key: string|int, provider: int|null, index: int}|null
+     */
+    public function dataSetOf(Identity $identity): ?array
+    {
+        return $this->dataSets[$identity->runtimeId] ?? null;
+    }
+
+    /**
+     * @return list<array{number: int<1, max>, result: TestResult}>
+     */
+    public function discardedAttemptsOf(Identity $identity): array
+    {
+        return $this->attempts[$identity->runtimeId] ?? [];
+    }
+
+    /**
+     * The event carries nothing: its arrival is the timestamp.
+     */
+    private function onSessionStarting(): void
+    {
+        $this->startedAt ??= \microtime(true);
+    }
+
+    private function onTestStarting(TestPipelineStarting $event): void
+    {
+        $this->stampStart($event->testInfo->identity);
+    }
+
+    private function onDataSetStarting(TestDataSetStarting $event): void
+    {
+        $identity = $event->testInfo->identity;
+        $this->stampStart($identity);
+
+        $this->dataSets[$identity->runtimeId] = [
+            'key' => $event->dataSetKey,
+            'provider' => $event->providerIndex,
+            'index' => $event->datasetIndex,
+        ];
+    }
+
+    /**
+     * The attempt being announced is the *next* one, so the result carried alongside it is the attempt
+     * before — the one the interceptor is about to drop.
+     */
+    private function onTestRetrying(TestRetrying $event): void
+    {
+        $number = $event->attempt - 1;
+        $number >= 1 or $number = 1;
+
+        $this->attempts[$event->testInfo->identity->runtimeId][] = [
+            'number' => $number,
+            'result' => $event->previousRunResult,
+        ];
+    }
+
+    private function stampStart(Identity $identity): void
+    {
+        # First stamp wins: a retried test re-enters the pipeline under the same run id, and the test
+        # began when its first attempt did.
+        $this->starts[$identity->runtimeId] ??= \microtime(true) - $this->startedAt();
+    }
+}

--- a/core/Output/Html/Internal/ReportInput.php
+++ b/core/Output/Html/Internal/ReportInput.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Testo\Application\Config\Internal\Attribute\InflectableConfig;
+use Testo\Application\Config\Internal\Attribute\InputOption;
+
+/**
+ * CLI input for the HTML reporter.
+ *
+ * Two independent destinations, because the page and the data it renders are separate artifacts: a CI job
+ * may want only the document, an IDE only the page, a developer both.
+ *
+ * @internal
+ * @psalm-internal Testo\Output\Html
+ */
+#[InflectableConfig]
+final class ReportInput
+{
+    /**
+     * `--log-html=<path>` — a directory to fill, or a `.html` file to write everything into.
+     */
+    #[InputOption('log-html')]
+    public ?string $htmlPath = null;
+
+    /**
+     * `--log-report=<path>` — the report document on its own, for CI and external tooling.
+     */
+    #[InputOption('log-report')]
+    public ?string $dataPath = null;
+}

--- a/core/Output/Html/Internal/ReportKind.php
+++ b/core/Output/Html/Internal/ReportKind.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+/**
+ * What a {@see Destination} receives: the rendered page, or the document on its own.
+ *
+ * @internal
+ * @psalm-internal Testo\Output\Html
+ */
+enum ReportKind
+{
+    case Html;
+    case Data;
+}

--- a/core/Output/Html/Internal/ValuePrinter.php
+++ b/core/Output/Html/Internal/ValuePrinter.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+/**
+ * Renders a value the way a data set's arguments are read rather than the way they are stored.
+ *
+ * A report has to state what a test was called with, and the arguments are arbitrary PHP: closures,
+ * resources, objects with recursive references, strings the size of a fixture file. Nothing here tries
+ * to be a serializer — the point is a short, honest label. Long strings are cut, nested structures stop
+ * at a shallow depth, and anything without a readable form answers with its type.
+ *
+ * @internal
+ */
+final class ValuePrinter
+{
+    /** Longest string rendered in full; anything longer is cut and marked. */
+    private const STRING_LIMIT = 120;
+
+    /** How deep into arrays and objects to look before answering with the type alone. */
+    private const MAX_DEPTH = 2;
+
+    private function __construct() {}
+
+    /**
+     * Type of a value as a reader expects to see it — `string`, `int`, `array`, or a class name.
+     *
+     * @return non-empty-string
+     */
+    public static function type(mixed $value): string
+    {
+        return \is_object($value) ? $value::class : \get_debug_type($value);
+    }
+
+    public static function print(mixed $value, int $depth = 0): string
+    {
+        return match (true) {
+            $value === null => 'null',
+            $value === true => 'true',
+            $value === false => 'false',
+            \is_int($value), \is_float($value) => (string) $value,
+            \is_string($value) => self::string($value),
+            \is_array($value) => self::array($value, $depth),
+            $value instanceof \UnitEnum => '\\' . $value::class . '::' . $value->name,
+            \is_object($value) => self::object($value, $depth),
+            \is_resource($value) => 'resource(' . \get_resource_type($value) . ')',
+            default => \get_debug_type($value),
+        };
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function string(string $value): string
+    {
+        $cut = \mb_strlen($value) > self::STRING_LIMIT;
+        $cut and $value = \mb_substr($value, 0, self::STRING_LIMIT);
+
+        # Control characters would break a single-line label; the escapes read as the source would write
+        # them, which is what a reader comparing against the test file needs.
+        $escaped = \str_replace(
+            ["\\", "'", "\n", "\r", "\t"],
+            ['\\\\', "\\'", '\n', '\r', '\t'],
+            $value,
+        );
+
+        return "'" . $escaped . ($cut ? "…'" : "'");
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     * @return non-empty-string
+     */
+    private static function array(array $value, int $depth): string
+    {
+        if ($value === []) {
+            return '[]';
+        }
+
+        if ($depth >= self::MAX_DEPTH) {
+            return 'array(' . \count($value) . ')';
+        }
+
+        $isList = \array_is_list($value);
+        $parts = [];
+        $shown = 0;
+        foreach ($value as $key => $item) {
+            if ($shown === 5) {
+                $parts[] = '…';
+                break;
+            }
+
+            $parts[] = $isList
+                ? self::print($item, $depth + 1)
+                : self::print($key, $depth + 1) . ' => ' . self::print($item, $depth + 1);
+            ++$shown;
+        }
+
+        return '[' . \implode(', ', $parts) . ']';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function object(object $value, int $depth): string
+    {
+        $class = '\\' . $value::class;
+
+        # A value object's readable form is what it says about itself; anything else is named by its
+        # class, because dumping arbitrary state into a report is neither short nor safe.
+        if ($value instanceof \Stringable) {
+            return $depth >= self::MAX_DEPTH ? $class : $class . '(' . self::string((string) $value) . ')';
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $class . '(' . $value->format(\DATE_ATOM) . ')';
+        }
+
+        return $class;
+    }
+}

--- a/core/Output/Html/Internal/ValuePrinter.php
+++ b/core/Output/Html/Internal/ValuePrinter.php
@@ -31,7 +31,7 @@ final class ValuePrinter
      */
     public static function type(mixed $value): string
     {
-        return \is_object($value) ? $value::class : \get_debug_type($value);
+        return \get_debug_type($value);
     }
 
     public static function print(mixed $value, int $depth = 0): string

--- a/core/Output/Html/Internal/Writer.php
+++ b/core/Output/Html/Internal/Writer.php
@@ -20,12 +20,12 @@ use Internal\Path;
  *
  * @internal
  */
-final class Writer
+final readonly class Writer
 {
     private const STYLES_PLACEHOLDER = '{{styles}}';
     private const SCRIPTS_PLACEHOLDER = '{{scripts}}';
 
-    private readonly string $resources;
+    private string $resources;
 
     public function __construct(?string $resources = null)
     {

--- a/core/Output/Html/Internal/Writer.php
+++ b/core/Output/Html/Internal/Writer.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output\Html\Internal;
+
+use Internal\Path;
+
+/**
+ * Writes the report to disk, in either layout, and answers with its entry file.
+ *
+ * Both layouts have to open over `file://` with no server, which forbids more than fetching: XHR on
+ * local files, ES modules, dynamic `import()` and workers are all unavailable, because the origin is
+ * `null`. So the assets are a classic script and a plain stylesheet with relative paths, and the data
+ * arrives as a script assigning a global rather than as a fetched `.json`. The single-file layout removes
+ * every one of those constraints by having nothing to load at all.
+ *
+ * One template serves both: the writer substitutes either links to the assets or the assets themselves.
+ * Keeping two templates in step by hand is how a report ends up working in one layout only.
+ *
+ * @internal
+ */
+final class Writer
+{
+    private const STYLES_PLACEHOLDER = '{{styles}}';
+    private const SCRIPTS_PLACEHOLDER = '{{scripts}}';
+
+    private readonly string $resources;
+
+    public function __construct(?string $resources = null)
+    {
+        $this->resources = $resources ?? \dirname(__DIR__) . '/resources';
+    }
+
+    /**
+     * The file a consumer opens for a report written to this destination.
+     *
+     * Knowable before anything is written, which is what lets the write be announced up front: a
+     * `.html` destination is the entry file itself, any other is a directory with `index.html` in it.
+     */
+    public static function entryFile(Path $destination): Path
+    {
+        return $destination->extension() === 'html' ? $destination : $destination->join('index.html');
+    }
+
+    /**
+     * Writes the report in whichever layout the destination asks for.
+     *
+     * @param Path $destination A `.html` file to fill, or a directory to fill.
+     * @param array<non-empty-string, mixed> $document
+     * @return Path The entry file — what a consumer opens, and what the announcement points at.
+     */
+    public function writeHtml(Path $destination, array $document): Path
+    {
+        return $destination->extension() === 'html'
+            ? $this->writeFile($destination, $document)
+            : $this->writeDirectory($destination, $document);
+    }
+
+    /**
+     * Writes the document on its own — the data is a supported artifact in its own right, not only the
+     * input of a page.
+     *
+     * @param array<non-empty-string, mixed> $document
+     */
+    public function writeData(Path $file, array $document): Path
+    {
+        self::ensureDirectory($file->parent());
+        self::put($file, Json::artifact($document));
+
+        return $file;
+    }
+
+    private static function ensureDirectory(Path $directory): void
+    {
+        $path = (string) $directory;
+
+        \is_dir($path) || \mkdir($path, 0o755, true) || \is_dir($path) or throw new \RuntimeException(
+            "Unable to create the report directory {$path}.",
+        );
+    }
+
+    private static function put(Path $file, string $content): void
+    {
+        \file_put_contents((string) $file, $content) === false and throw new \RuntimeException(
+            'Unable to write the report file ' . (string) $file . '.',
+        );
+    }
+
+    /**
+     * Writes `index.html` plus its assets under the given directory.
+     *
+     * @param Path $directory Directory to fill; created when missing.
+     * @param array<non-empty-string, mixed> $document
+     * @return Path The entry file — what a consumer opens, and what the announcement points at.
+     */
+    private function writeDirectory(Path $directory, array $document): Path
+    {
+        $assets = $directory->join('assets');
+        self::ensureDirectory($assets);
+
+        self::put($assets->join('report.css'), $this->resource('assets/report.css'));
+        self::put($assets->join('report.js'), $this->resource('assets/report.js'));
+        self::put($assets->join('data.js'), Json::script($document));
+
+        $entry = $directory->join('index.html');
+        self::put($entry, \str_replace(
+            [self::STYLES_PLACEHOLDER, self::SCRIPTS_PLACEHOLDER],
+            [
+                '<link rel="stylesheet" href="assets/report.css">',
+                '<script src="assets/data.js"></script>' . "\n" . '<script src="assets/report.js"></script>',
+            ],
+            $this->resource('index.html'),
+        ));
+
+        return $entry;
+    }
+
+    /**
+     * Writes the whole report as one document with everything inlined.
+     *
+     * @param Path $file Target file; its parent directory is created when missing.
+     * @param array<non-empty-string, mixed> $document
+     * @return Path The file itself, which is also the entry file.
+     */
+    private function writeFile(Path $file, array $document): Path
+    {
+        self::ensureDirectory($file->parent());
+
+        self::put($file, \str_replace(
+            [self::STYLES_PLACEHOLDER, self::SCRIPTS_PLACEHOLDER],
+            [
+                '<style>' . "\n" . $this->resource('assets/report.css') . '</style>',
+                '<script>' . "\n" . Json::script($document) . '</script>' . "\n"
+                . '<script>' . "\n" . $this->resource('assets/report.js') . '</script>',
+            ],
+            $this->resource('index.html'),
+        ));
+
+        return $file;
+    }
+
+    private function resource(string $name): string
+    {
+        $path = $this->resources . '/' . $name;
+        $content = \file_get_contents($path);
+
+        $content === false and throw new \RuntimeException("Unable to read the report asset {$path}.");
+
+        return $content;
+    }
+}

--- a/core/Output/Html/resources/assets/report.css
+++ b/core/Output/Html/resources/assets/report.css
@@ -867,6 +867,8 @@ details.fold > summary:hover { color: var(--ink); }
     padding: 2px 0;
     /* Multi-line content must not drag the timestamp and the channel badge to its middle. */
     align-items: start;
+    /* Anchors the hover-revealed copy button. */
+    position: relative;
 }
 
 .log .line:hover { background: var(--surface-2); }
@@ -894,6 +896,69 @@ details.fold > summary:hover { color: var(--ink); }
 .log .lv-debug { color: var(--muted); }
 .log .from { color: var(--muted); }
 .log .from a { color: var(--muted); }
+
+/* A streaming channel (stdout/stderr) is one row of reassembled output, not a row per chunk. */
+.log .line.stream .stream-body { white-space: normal; }
+.stream-block {
+    display: block;
+    white-space: pre-wrap;
+    word-break: break-word;
+    /* An empty block is a blank line the output actually held; keep it visible. */
+    min-height: 1.6em;
+}
+/* Only a chunk that carries a tip (one of several in its message) is interactive; a sole chunk is inert. */
+.chunk[data-tip] { border-radius: 2px; cursor: help; }
+.chunk[data-tip]:hover {
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.chunk.lv-warning { color: var(--st-flaky); }
+.chunk.lv-error, .chunk.lv-critical { color: var(--st-failed); }
+.chunk.lv-debug { color: var(--muted); }
+
+/* Copy button: hidden until the row is hovered, anchored to its top-right. */
+.copy-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: none;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    font: 12px/1 var(--sans);
+    color: var(--muted);
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 5px;
+    cursor: pointer;
+}
+.log .line:hover .copy-btn { display: grid; }
+.copy-btn:hover { color: var(--ink); border-color: var(--ink); }
+/* Feedback stays put while the tick or cross shows, so it does not vanish with the pointer. */
+.copy-btn.copied { display: grid; color: var(--st-passed); border-color: currentColor; }
+.copy-btn.failed { display: grid; color: var(--st-failed); border-color: currentColor; }
+
+/* Shared scripted hover tip: what a native title would say, but shown at once and styled. Any element
+   with a `data-tip` attribute drives it (see report.js). */
+.tip {
+    position: fixed;
+    z-index: 60;
+    display: none;
+    max-width: 460px;
+    padding: 6px 9px;
+    font: 11px/1.5 var(--mono);
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 7px;
+    box-shadow: 0 6px 22px rgba(11, 11, 11, .16);
+    /* Honour newlines a producer put in the text, and wrap the rest at the max width. */
+    white-space: pre-line;
+    word-break: break-word;
+    pointer-events: none;
+}
+.tip.on { display: block; }
 
 .channel-picker { display: grid; gap: 2px; padding: 6px; }
 

--- a/core/Output/Html/resources/assets/report.css
+++ b/core/Output/Html/resources/assets/report.css
@@ -1,0 +1,1074 @@
+/* Testo HTML report — prototype stylesheet. Classic <link>, no build step, file:// safe. */
+
+:root {
+    color-scheme: light;
+
+    --plane: #f9f9f7;
+    --surface: #fcfcfb;
+    --surface-2: #f3f2ef;
+    --ink: #0b0b0b;
+    --ink-2: #52514e;
+    --muted: #898781;
+    --grid: #e1e0d9;
+    --axis: #c3c2b7;
+    --border: rgba(11, 11, 11, .10);
+    --border-strong: rgba(11, 11, 11, .18);
+    --accent: #2a78d6;
+    --shadow: 0 1px 2px rgba(11, 11, 11, .05), 0 8px 24px rgba(11, 11, 11, .04);
+
+    /*
+     * Six hues carry eight statuses. Error shares the Failed hue and Cancelled the Skipped one,
+     * separated by a 45° stripe — a second channel, because a seventh and eighth hue cannot clear
+     * the CVD floors beside the six. Every status also ships an icon and a label, so colour never
+     * carries the meaning alone. The paint order of the stacked bar (see BAR_ORDER in report.js)
+     * keeps green away from red: adjacent, they measure ΔE 4.1 under deuteranopia.
+     */
+    --st-passed: #0ca30c;
+    --st-failed: #d03b3b;
+    --st-error: #d03b3b;
+    --st-error-stripe: #8f2626;
+    --st-risky: #ec835a;
+    --st-flaky: #fab219;
+    --st-skipped: #898781;
+    --st-cancelled: #898781;
+    --st-cancelled-stripe: #5f5e59;
+    --st-aborted: #4a3aa7;
+
+    --sev-danger: #d03b3b;
+    --sev-warning: #fab219;
+    --sev-notice: #2a78d6;
+
+    --radius: 10px;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+        color-scheme: dark;
+
+        --plane: #0d0d0d;
+        --surface: #1a1a19;
+        --surface-2: #222221;
+        --ink: #ffffff;
+        --ink-2: #c3c2b7;
+        --muted: #898781;
+        --grid: #2c2c2a;
+        --axis: #383835;
+        --border: rgba(255, 255, 255, .10);
+        --border-strong: rgba(255, 255, 255, .18);
+        --accent: #3987e5;
+        --shadow: none;
+
+        --st-aborted: #9085e9;
+    }
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+
+    --plane: #0d0d0d;
+    --surface: #1a1a19;
+    --surface-2: #222221;
+    --ink: #ffffff;
+    --ink-2: #c3c2b7;
+    --muted: #898781;
+    --grid: #2c2c2a;
+    --axis: #383835;
+    --border: rgba(255, 255, 255, .10);
+    --border-strong: rgba(255, 255, 255, .18);
+    --accent: #3987e5;
+    --shadow: none;
+
+    --st-aborted: #9085e9;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
+/*
+ * The gutter is reserved whether a view scrolls or not. A tab that fits the viewport is otherwise
+ * a scrollbar wider than one that overflows, and every centred element shifts as tabs change.
+ */
+html {
+    scrollbar-gutter: stable;
+}
+
+@supports not (scrollbar-gutter: stable) {
+    html {
+        overflow-y: scroll;
+    }
+}
+
+body {
+    background: var(--plane);
+    color: var(--ink);
+    font: 14px/1.5 var(--sans);
+    -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); }
+
+code, pre, .mono { font-family: var(--mono); }
+
+/* ---------- shell ---------------------------------------------------------- */
+
+.shell {
+    padding: 0 20px 48px;
+}
+
+header.top {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: color-mix(in srgb, var(--plane) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+}
+
+.top-row {
+    padding: 14px 20px 0;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.brand {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-weight: 650;
+    letter-spacing: -.01em;
+}
+
+.brand .v {
+    font: 400 11px/1 var(--mono);
+    color: var(--muted);
+}
+
+.run-verdict {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 4px 11px 4px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    font-weight: 650;
+    font-size: 12px;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.top-meta {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    color: var(--ink-2);
+    font-size: 12.5px;
+}
+
+.top-meta .kv b {
+    font-weight: 600;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+}
+
+.theme-toggle {
+    appearance: none;
+    background: var(--surface);
+    color: var(--ink-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    height: 28px;
+    padding: 0 10px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+}
+
+.theme-toggle:hover { border-color: var(--border-strong); color: var(--ink); }
+
+nav.tabs {
+    padding: 10px 20px 0;
+    display: flex;
+    gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+nav.tabs::-webkit-scrollbar { display: none; }
+
+nav.tabs a {
+    position: relative;
+    padding: 8px 12px 11px;
+    color: var(--ink-2);
+    text-decoration: none;
+    font-size: 13.5px;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+}
+
+nav.tabs a:hover { color: var(--ink); }
+
+nav.tabs a[aria-current="page"] {
+    color: var(--ink);
+    font-weight: 600;
+    border-bottom-color: var(--accent);
+}
+
+nav.tabs a .n {
+    margin-left: 5px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    font-weight: 400;
+}
+
+/* ---------- cards --------------------------------------------------------- */
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.card > h2, .card > header {
+    margin: 0;
+    padding: 13px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+    font-weight: 650;
+    letter-spacing: .01em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.card > header .hint {
+    margin-left: auto;
+    font-weight: 400;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.card .body { padding: 16px; }
+
+.grid {
+    display: grid;
+    gap: 14px;
+    margin-top: 18px;
+    align-items: start;
+}
+
+.grid.cols-2 { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+.grid.cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+@media (max-width: 1080px) {
+    .grid.cols-2, .grid.cols-3 { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* ---------- hero + stat tiles --------------------------------------------- */
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-top: 18px;
+}
+
+.hero .cell {
+    background: var(--surface);
+    padding: 14px 16px 15px;
+}
+
+.hero .label {
+    color: var(--muted);
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+}
+
+.hero .value {
+    margin-top: 4px;
+    font-size: 26px;
+    font-weight: 640;
+    letter-spacing: -.02em;
+    line-height: 1.15;
+}
+
+.hero .sub {
+    margin-top: 2px;
+    color: var(--ink-2);
+    font-size: 12px;
+}
+
+.tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+    gap: 10px;
+}
+
+.tile {
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    padding: 10px 12px 11px;
+    background: var(--surface);
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
+.tile:hover { border-color: var(--border-strong); background: var(--surface-2); }
+
+.tile .head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--ink-2);
+    font-size: 12px;
+}
+
+.tile .num {
+    margin-top: 3px;
+    font-size: 22px;
+    font-weight: 640;
+    letter-spacing: -.02em;
+    font-variant-numeric: tabular-nums;
+}
+
+.tile .pct { margin-left: 6px; font-size: 12px; font-weight: 400; color: var(--muted); }
+
+/* ---------- status vocabulary --------------------------------------------- */
+
+.dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex: none;
+    display: inline-block;
+    box-shadow: 0 0 0 2px var(--surface);
+}
+
+.ico {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.s-passed { color: var(--st-passed); }
+.s-failed { color: var(--st-failed); }
+.s-error { color: var(--st-error); }
+.s-risky { color: var(--st-risky); }
+.s-flaky { color: var(--st-flaky); }
+.s-skipped { color: var(--st-skipped); }
+.s-cancelled { color: var(--st-cancelled); }
+.s-aborted { color: var(--st-aborted); }
+
+.bg-passed { background: var(--st-passed); }
+.bg-failed { background: var(--st-failed); }
+.bg-risky { background: var(--st-risky); }
+.bg-flaky { background: var(--st-flaky); }
+.bg-skipped { background: var(--st-skipped); }
+.bg-aborted { background: var(--st-aborted); }
+
+/* The textured pair: same hue as its family, told apart by a 45° stripe. */
+.bg-error {
+    background: repeating-linear-gradient(45deg,
+    var(--st-error) 0 4px, var(--st-error-stripe) 4px 7px);
+}
+
+.bg-cancelled {
+    background: repeating-linear-gradient(45deg,
+    var(--st-cancelled) 0 4px, var(--st-cancelled-stripe) 4px 7px);
+}
+
+/* Shape is the third channel: a striped status carries a square swatch, a solid one a circle. */
+.dot.textured { border-radius: 2px; }
+
+/* 100 % stacked status bar: 2px surface gaps, rounded outer ends. */
+.stackbar {
+    display: flex;
+    gap: 2px;
+    height: 26px;
+    margin-bottom: 14px;
+}
+
+.stackbar > span {
+    min-width: 3px;
+    border-radius: 2px;
+}
+
+.stackbar > span:first-child { border-radius: 4px 2px 2px 4px; }
+.stackbar > span:last-child { border-radius: 2px 4px 4px 2px; }
+
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+}
+
+.legend .item {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 12.5px;
+    color: var(--ink-2);
+}
+
+.legend .item b {
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
+
+/* ---------- bars ---------------------------------------------------------- */
+
+.barlist { display: grid; gap: 9px; }
+
+.barlist .row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 70px;
+    align-items: center;
+    gap: 10px;
+}
+
+.barlist .name {
+    font-size: 12.5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--ink-2);
+    text-decoration: none;
+}
+
+.barlist .name:hover { color: var(--ink); text-decoration: underline; }
+
+.barlist .track {
+    grid-column: 1 / 2;
+    height: 8px;
+    background: var(--grid);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.barlist .fill {
+    height: 8px;
+    border-radius: 0 4px 4px 0;
+    background: var(--accent);
+}
+
+.barlist .val {
+    grid-row: span 2;
+    grid-column: 2;
+    text-align: right;
+    font: 12px/1 var(--mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-2);
+}
+
+.phases {
+    display: flex;
+    gap: 2px;
+    height: 22px;
+    margin-bottom: 12px;
+}
+
+/*
+ * Phases are ordinal steps of one measure, so they take one hue light→dark rather than a
+ * categorical set. Steps 300–600 of the blue ramp: every one clears 2:1 against both surfaces,
+ * which an opacity fade would not on the dark plane.
+ */
+.phases > span { border-radius: 2px; background: #6da7ec; }
+.phases > span:nth-child(2) { background: #3987e5; }
+.phases > span:nth-child(3) { background: #256abf; }
+.phases > span:nth-child(4) { background: #184f95; }
+
+/* The legend reuses the same nth-child steps, so the two never drift apart. */
+.phases-legend .item:nth-child(1) .dot { background: #6da7ec; }
+.phases-legend .item:nth-child(2) .dot { background: #3987e5; }
+.phases-legend .item:nth-child(3) .dot { background: #256abf; }
+.phases-legend .item:nth-child(4) .dot { background: #184f95; }
+
+/* The tests phase, split into what ran and the framework overhead around it. */
+.phase-stats {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+}
+
+/* ---------- tables -------------------------------------------------------- */
+
+table.grid-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+table.grid-table th {
+    text-align: left;
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--muted);
+    font-weight: 600;
+    padding: 0 10px 8px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+table.grid-table td {
+    padding: 8px 10px 8px 0;
+    border-bottom: 1px solid var(--grid);
+    vertical-align: middle;
+}
+
+table.grid-table tr:last-child td { border-bottom: 0; }
+table.grid-table .num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono); font-size: 12px; }
+table.grid-table .best { color: var(--st-passed); font-weight: 600; }
+
+.minibar {
+    display: flex;
+    gap: 2px;
+    height: 7px;
+    width: 130px;
+}
+
+.minibar > span { border-radius: 2px; min-width: 2px; }
+
+/* ---------- filters ------------------------------------------------------- */
+
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-top: 18px;
+    padding: 10px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.filters input[type="search"], .filters select {
+    appearance: none;
+    font: inherit;
+    font-size: 13px;
+    color: var(--ink);
+    background: var(--plane);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    height: 30px;
+    padding: 0 9px;
+}
+
+.filters input[type="search"] { min-width: 230px; flex: 1 1 230px; }
+.filters select { padding-right: 22px; }
+.filters input:focus, .filters select:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+
+.chips { display: flex; flex-wrap: wrap; gap: 6px; }
+
+.chip {
+    appearance: none;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 30px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--plane);
+    color: var(--ink-2);
+}
+
+.chip:hover { border-color: var(--border-strong); color: var(--ink); }
+
+.chip[aria-pressed="true"] {
+    background: var(--surface-2);
+    border-color: var(--border-strong);
+    color: var(--ink);
+    font-weight: 600;
+}
+
+.chip .n { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+/* A facet the current filter leaves empty stays in place — the vocabulary is fixed — but recedes. */
+.chip.is-zero { opacity: .45; }
+
+.filters .reset { margin-left: auto; }
+
+.filters .count { font-size: 12.5px; color: var(--muted); }
+
+/* ---------- tests: two panes ---------------------------------------------- */
+
+.panes {
+    display: grid;
+    grid-template-columns: minmax(340px, 460px) minmax(0, 1fr);
+    gap: 14px;
+    margin-top: 14px;
+    align-items: start;
+}
+
+@media (max-width: 1080px) {
+    .panes { grid-template-columns: minmax(0, 1fr); }
+}
+
+.tree { padding: 6px; max-height: calc(100vh - 240px); overflow: auto; }
+
+.tree .suite > .head, .tree .case > .head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 7px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.tree .suite > .head:hover, .tree .case > .head:hover { background: var(--surface-2); }
+
+.tree .suite > .head { font-weight: 640; font-size: 13px; }
+
+.tree .case > .head {
+    font-size: 12.5px;
+    color: var(--ink-2);
+    font-family: var(--mono);
+}
+
+/*
+ * One step per level, and a test row carries a spacer the width of the twisty it does not have —
+ * so a child's status icon always sits to the right of its parent's, never left of the parent name.
+ */
+.tree .case, .tree .tests { margin-left: 18px; }
+
+.tree .twisty, .tree .spacer {
+    width: 22px;
+    flex: none;
+    font: 11px/1 var(--mono);
+    color: var(--muted);
+}
+
+.tree .twisty::before { content: "[-]"; }
+.tree .collapsed > .head .twisty::before { content: "[+]"; }
+.tree .suite > .head:hover .twisty, .tree .case > .head:hover .twisty { color: var(--ink); }
+.tree .collapsed > .kids { display: none; }
+
+.tree .head .tail {
+    margin-left: auto;
+    font: 11.5px/1 var(--mono);
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.tree .test {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    text-align: left;
+    padding: 5px 8px;
+    border-radius: 7px;
+    text-decoration: none;
+    color: var(--ink);
+    font-size: 13px;
+}
+
+.tree .test:hover { background: var(--surface-2); }
+
+.tree .test[aria-current="true"] {
+    background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+    box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.tree .test .tname { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tree .test .badges { margin-left: auto; display: flex; align-items: center; gap: 6px; flex: none; }
+.tree .test .dur { font: 11.5px/1 var(--mono); color: var(--muted); font-variant-numeric: tabular-nums; }
+
+.pill {
+    font-size: 10.5px;
+    line-height: 1;
+    padding: 3px 6px;
+    border-radius: 5px;
+    border: 1px solid var(--border-strong);
+    color: var(--ink-2);
+    text-transform: uppercase;
+    letter-spacing: .04em;
+}
+
+/* ---------- detail -------------------------------------------------------- */
+
+.detail .headline { padding: 16px 16px 14px; border-bottom: 1px solid var(--border); }
+
+.detail .headline .crumbs {
+    font: 11.5px/1.4 var(--mono);
+    color: var(--muted);
+    word-break: break-all;
+}
+
+.detail .headline h3 {
+    margin: 6px 0 0;
+    font-size: 19px;
+    letter-spacing: -.01em;
+    font-weight: 650;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    flex-wrap: wrap;
+}
+
+.detail .headline .desc { margin-top: 5px; color: var(--ink-2); }
+
+.detail .facts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 22px;
+    margin-top: 12px;
+    font-size: 12.5px;
+    color: var(--ink-2);
+}
+
+.detail .facts b { color: var(--ink); font-variant-numeric: tabular-nums; }
+
+.section { border-bottom: 1px solid var(--border); padding: 14px 16px; }
+.section:last-child { border-bottom: 0; }
+
+.section > h4 {
+    margin: 0 0 10px;
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--muted);
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.failure {
+    border: 1px solid color-mix(in srgb, var(--st-failed) 34%, var(--border));
+    border-left: 3px solid var(--st-failed);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--st-failed) 5%, var(--surface));
+    padding: 11px 13px;
+}
+
+.failure .cls { font: 12px/1.4 var(--mono); color: var(--st-failed); font-weight: 600; }
+.failure .msg { margin-top: 5px; white-space: pre-wrap; }
+
+.failure .loc {
+    margin-top: 8px;
+    font: 12px/1.5 var(--mono);
+    color: var(--ink-2);
+}
+
+pre.code {
+    margin: 8px 0 0;
+    padding: 10px 12px;
+    background: var(--plane);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    overflow-x: auto;
+    font-size: 12px;
+    line-height: 1.55;
+    white-space: pre;
+}
+
+pre.code.wrap { white-space: pre-wrap; word-break: break-word; }
+
+.diff { display: grid; }
+
+.diff .l { font: 12px/1.6 var(--mono); padding: 0 8px; white-space: pre-wrap; }
+.diff .l.add { background: color-mix(in srgb, var(--st-passed) 12%, transparent); color: var(--ink); }
+.diff .l.del { background: color-mix(in srgb, var(--st-failed) 12%, transparent); color: var(--ink); }
+.diff .l.ctx { color: var(--ink-2); }
+
+.trace { font: 12px/1.7 var(--mono); }
+.trace .frame { display: flex; gap: 8px; }
+.trace .i { color: var(--muted); flex: none; }
+.trace .where { color: var(--ink-2); word-break: break-all; }
+.trace .where .call { color: var(--ink); }
+
+details.fold > summary {
+    cursor: pointer;
+    font-size: 12.5px;
+    color: var(--ink-2);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+details.fold > summary::-webkit-details-marker { display: none; }
+details.fold > summary::before { content: "▸"; color: var(--muted); font-size: 10px; }
+details.fold[open] > summary::before { content: "▾"; }
+details.fold > summary:hover { color: var(--ink); }
+
+.attempts { display: grid; gap: 8px; }
+
+.attempt {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 9px 11px;
+}
+
+.attempt > .head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12.5px;
+}
+
+.attempt > .head .n { font-weight: 640; }
+.attempt > .head .dur { margin-left: auto; font: 11.5px/1 var(--mono); color: var(--muted); }
+.attempt.kept { border-color: color-mix(in srgb, var(--st-passed) 40%, var(--border)); }
+.attempt.discarded { background: var(--surface-2); }
+
+.notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 9px 11px;
+    border-radius: 8px;
+    font-size: 12.5px;
+    border: 1px solid color-mix(in srgb, var(--st-flaky) 42%, var(--border));
+    background: color-mix(in srgb, var(--st-flaky) 9%, var(--surface));
+    color: var(--ink-2);
+}
+
+.notice.info {
+    border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+    background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+}
+
+/* ---------- channel log --------------------------------------------------- */
+
+.log { font: 12px/1.6 var(--mono); }
+
+.log .line {
+    display: grid;
+    grid-template-columns: 74px 152px minmax(0, 1fr);
+    gap: 10px;
+    padding: 2px 0;
+    /* Multi-line content must not drag the timestamp and the channel badge to its middle. */
+    align-items: start;
+}
+
+.log .line:hover { background: var(--surface-2); }
+
+/* Filtering hides; hovering a channel button previews what that filter would keep. */
+.is-hidden { display: none !important; }
+.log .line.hl { background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.log .line.dim { opacity: .3; }
+.log .t { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+.log .ch {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.log .ch .swatch { width: 3px; height: 13px; border-radius: 2px; flex: none; }
+.log .content { white-space: pre-wrap; word-break: break-word; }
+.log .lv { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; }
+.log .lv-warning { color: var(--st-flaky); }
+.log .lv-error, .log .lv-critical { color: var(--st-failed); }
+.log .lv-debug { color: var(--muted); }
+.log .from { color: var(--muted); }
+.log .from a { color: var(--muted); }
+
+.channel-picker { display: grid; gap: 2px; padding: 6px; }
+
+.channel-picker button {
+    appearance: none;
+    font: inherit;
+    font-size: 12.5px;
+    cursor: pointer;
+    background: none;
+    border: 0;
+    border-radius: 7px;
+    padding: 6px 8px;
+    text-align: left;
+    color: var(--ink-2);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.channel-picker button:hover { background: var(--surface-2); color: var(--ink); }
+
+.channel-picker button[aria-pressed="true"] {
+    background: var(--surface-2);
+    color: var(--ink);
+    font-weight: 600;
+}
+
+.channel-picker button .n { margin-left: auto; color: var(--muted); font-variant-numeric: tabular-nums; font-weight: 400; }
+
+/* ---------- timeline ------------------------------------------------------ */
+
+/*
+ * Zoom stretches the lane and nothing else: the canvas grows past its scroll port by the zoom
+ * factor, while the label column keeps its width and sticks to the left edge, so a name stays
+ * readable however far the lane is scrolled.
+ */
+.timeline {
+    --tl-label: 360px;
+    --tl-zoom: 1;
+    position: relative;
+}
+
+.tl-tools {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 10px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.tl-tools .chip { height: 26px; padding: 0 9px; font-variant-numeric: tabular-nums; }
+
+/* The chart scrolls inside the card so the axis and the labels can stay pinned to its edges. */
+.tl-scroll {
+    max-height: calc(100vh - 280px);
+    overflow: auto;
+}
+
+.tl-canvas {
+    min-width: 100%;
+    width: calc(var(--tl-label) + (100% - var(--tl-label)) * var(--tl-zoom));
+}
+
+.tl-head {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--surface);
+}
+
+.tl-axis {
+    position: relative;
+    height: 20px;
+    margin-left: var(--tl-label);
+    border-bottom: 1px solid var(--axis);
+}
+
+.tl-axis .tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid var(--grid);
+    padding-left: 4px;
+    font: 11px/20px var(--mono);
+    color: var(--muted);
+}
+
+.tl-row {
+    display: grid;
+    grid-template-columns: var(--tl-label) minmax(0, 1fr);
+    gap: 0;
+    align-items: center;
+    height: 22px;
+}
+
+.tl-row:hover { background: var(--surface-2); }
+
+.tl-row .label {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: var(--surface);
+    border-right: 1px solid var(--grid);
+    font-size: 12px;
+    color: var(--ink-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-right: 10px;
+    text-decoration: none;
+}
+
+.tl-row:hover .label { background: var(--surface-2); }
+
+.tl-row .label:hover { color: var(--ink); }
+
+@media (max-width: 1080px) {
+    .timeline { --tl-label: 200px; }
+}
+
+.tl-lane { position: relative; height: 22px; }
+
+.tl-lane .bar {
+    position: absolute;
+    top: 6px;
+    height: 10px;
+    min-width: 3px;
+    border-radius: 3px;
+    box-shadow: 0 0 0 2px var(--surface);
+}
+
+.tl-lane .bar:hover { outline: 2px solid var(--ink); outline-offset: 1px; }
+
+/* ---------- env / kv ------------------------------------------------------ */
+
+.kv-list { display: grid; grid-template-columns: 170px minmax(0, 1fr); gap: 7px 16px; font-size: 13px; }
+.kv-list dt { color: var(--muted); }
+.kv-list dd { margin: 0; font-family: var(--mono); font-size: 12.5px; word-break: break-all; }
+
+.tag {
+    display: inline-block;
+    font: 11.5px/1 var(--mono);
+    padding: 4px 7px;
+    margin: 0 4px 4px 0;
+    border-radius: 5px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+}
+
+.tag.neg { border-color: color-mix(in srgb, var(--st-failed) 40%, var(--border)); color: var(--st-failed); }
+
+.empty { padding: 40px 16px; text-align: center; color: var(--muted); font-size: 13px; }
+
+.sev {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+}
+
+.sev-danger { color: var(--sev-danger); }
+.sev-warning { color: var(--sev-warning); }
+.sev-notice { color: var(--sev-notice); }
+
+.schema-error {
+    max-width: 620px;
+    margin: 80px auto;
+    padding: 20px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in srgb, var(--st-failed) 40%, var(--border));
+    background: color-mix(in srgb, var(--st-failed) 6%, var(--surface));
+}
+
+@media print {
+    header.top, nav.tabs, .filters { display: none; }
+    .card { break-inside: avoid; box-shadow: none; }
+}

--- a/core/Output/Html/resources/assets/report.js
+++ b/core/Output/Html/resources/assets/report.js
@@ -71,6 +71,18 @@
         'retry': '#fab219'
     };
 
+    /**
+     * Channels whose messages are chunks of one byte stream, not discrete records. Output capture writes
+     * a chunk per flush, so a bare `echo` is not a "message": giving each its own row, timestamp and level
+     * shreds a single line of output across the log. A streaming channel is reassembled instead —
+     * consecutive chunks join into a continuous run, a chunk ending in a newline closes the block the next
+     * one opens after, and any other channel wedging in splits the run where it lands. Each chunk stays a
+     * hoverable element carrying its own arrival time and level.
+     */
+    var STREAMING_CHANNELS = {'stdout': true, 'stderr': true};
+
+    function isStreaming(name) { return STREAMING_CHANNELS[name] === true; }
+
     /* ------------------------------------------------------------------ helpers */
 
     function el(id) { return document.getElementById(id); }
@@ -861,20 +873,115 @@
     }
 
     function logHtml(lines, withTest) {
-        return '<div class="log">' + lines.map(function (m) {
-            var ch = channelOf(m.channel);
-            return '<div class="line" data-ch="' + esc(m.channel) + '">'
-                + '<span class="t">+' + m.time.toFixed(3) + '</span>'
-                + '<span class="ch"><span class="swatch" style="background:' + esc(ch.color) + '"></span>'
-                + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span>'
-                + '<span>' + esc(m.channel) + '</span>'
-                + '<span class="lv lv-' + esc(m.level) + '">' + esc(m.level) + '</span></span>'
-                + '<span class="content">' + esc(m.content.replace(/\n$/, ''))
-                + (withTest && m.test ? '<span class="from">  ← <a href="'
-                    + href('tests', {}, m.test.id) + '">' + esc(m.test.name)
-                    + (m.attempt ? ' #' + m.attempt : '') + '</a></span>' : '')
-                + '</span></div>';
+        // Group the ordered run: a maximal run of one streaming channel becomes a single reassembled row,
+        // everything else stays one row per message. A message of any other channel ends the run in
+        // progress, so the next chunk of the stream opens a fresh row where the interruption landed.
+        var groups = [];
+        var stream = null;
+        lines.forEach(function (m) {
+            if (isStreaming(m.channel) && stream && stream.channel === m.channel) {
+                stream.chunks.push(m);
+                return;
+            }
+            if (isStreaming(m.channel)) {
+                stream = {channel: m.channel, chunks: [m]};
+                groups.push({stream: stream});
+                return;
+            }
+            stream = null;
+            groups.push({line: m});
+        });
+
+        return '<div class="log">' + groups.map(function (g) {
+            return g.stream ? streamHtml(g.stream, withTest) : lineHtml(g.line, withTest);
         }).join('') + '</div>';
+    }
+
+    /** The source-test suffix a merged view appends: which test, and which retry, wrote the message. */
+    function fromHtml(m) {
+        return '<span class="from">  ← <a href="' + href('tests', {}, m.test.id) + '">'
+            + esc(m.test.name) + (m.attempt ? ' #' + m.attempt : '') + '</a></span>';
+    }
+
+    /** One discrete message: a row of time · channel · level · content. */
+    function lineHtml(m, withTest) {
+        var ch = channelOf(m.channel);
+        return '<div class="line" data-ch="' + esc(m.channel) + '" data-copy="' + esc(m.content) + '">'
+            + '<span class="t">+' + m.time.toFixed(3) + '</span>'
+            + '<span class="ch"><span class="swatch" style="background:' + esc(ch.color) + '"></span>'
+            + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span>'
+            + '<span>' + esc(m.channel) + '</span>'
+            + '<span class="lv lv-' + esc(m.level) + '">' + esc(m.level) + '</span></span>'
+            + '<span class="content">' + esc(m.content.replace(/\n$/, ''))
+            + (withTest && m.test ? fromHtml(m) : '')
+            + '</span>' + copyBtn() + '</div>';
+    }
+
+    /**
+     * A streaming channel's run reassembled into one row. The left columns carry the run's start and its
+     * channel; the content is the stream rebuilt — chunks concatenated in place, broken into blocks at the
+     * newlines that ended a chunk, each chunk its own hoverable span. No level badge: a run has no single
+     * level, so each chunk keeps its own in its hover hint. No whitespace may sit between chunk spans in
+     * the markup, or `pre-wrap` would render it as output that was never there.
+     */
+    function streamHtml(stream, withTest) {
+        var ch = channelOf(stream.channel);
+        var first = stream.chunks[0];
+        // The message copies whole: the raw stream this row rebuilt, every chunk in order, newlines kept.
+        var copy = stream.chunks.map(function (m) { return m.content; }).join('');
+        // A lone chunk is the whole message — nothing to tell apart within it, so it gets no per-chunk tip.
+        var multi = stream.chunks.length > 1;
+
+        var blocks = [[]];
+        stream.chunks.forEach(function (m) {
+            blocks[blocks.length - 1].push(m);
+            /\n$/.test(m.content) && blocks.push([]);
+        });
+        blocks[blocks.length - 1].length || blocks.pop();
+
+        var body = blocks.map(function (chunks) {
+            return '<span class="stream-block">' + chunks.map(function (m) {
+                return chunkHtml(m, withTest, multi);
+            }).join('') + '</span>';
+        }).join('');
+
+        // A merged view still names the source when the whole run came from one test; a run that spans
+        // several leaves the attribution to each chunk's hover hint rather than picking one to show.
+        var sameTest = withTest && first.test && stream.chunks.every(function (m) {
+            return m.test === first.test && m.attempt === first.attempt;
+        });
+
+        return '<div class="line stream" data-ch="' + esc(stream.channel) + '" data-copy="' + esc(copy) + '">'
+            + '<span class="t">+' + first.time.toFixed(3) + '</span>'
+            + '<span class="ch"><span class="swatch" style="background:' + esc(ch.color) + '"></span>'
+            + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span>'
+            + '<span>' + esc(stream.channel) + '</span></span>'
+            + '<span class="content stream-body">' + body + (sameTest ? fromHtml(first) : '')
+            + '</span>' + copyBtn() + '</div>';
+    }
+
+    /**
+     * One chunk of a stream: an inline span holding its raw content, with its channel, arrival, level and
+     * source composed into the shared hover tip (see {@see bindTips}). A native `title` is too slow to
+     * surface and cannot be styled, so the scripted tip carries the detail a chunk is too small to show.
+     *
+     * A sole chunk (`multi` false) keeps its level colour but drops the tip and the hover: it is the whole
+     * message, and the row's copy button already offers what a hover would.
+     */
+    function chunkHtml(m, withTest, multi) {
+        var content = esc(m.content.replace(/\n$/, ''));
+        if (!multi) {
+            return '<span class="chunk lv-' + esc(m.level) + '">' + content + '</span>';
+        }
+
+        var from = withTest && m.test ? ' · ← ' + m.test.name + (m.attempt ? ' #' + m.attempt : '') : '';
+        var tip = m.channel + ' · +' + m.time.toFixed(3) + 's · ' + m.level + from;
+        return '<span class="chunk lv-' + esc(m.level) + '" data-tip="' + esc(tip) + '">' + content + '</span>';
+    }
+
+    /** The hover-revealed copy button every log row carries; the row holds the exact text in `data-copy`. */
+    function copyBtn() {
+        return '<button class="copy-btn" type="button" data-tip="Copy" aria-label="Copy message">⧉</button>';
     }
 
     /* --------------------------------------------------------------- tab: channels */
@@ -1132,6 +1239,8 @@
         route = parseHash();
         // A real navigation supersedes whatever was being typed; replaceState never gets here.
         liveQuery = null;
+        // The hovered element is about to be replaced; drop any tip anchored to it before it vanishes.
+        hideTip();
         renderChrome();
 
         var body = el('view');
@@ -1346,6 +1455,131 @@
         });
     }
 
+    /* ----------------------------------------------------------------------- tip */
+
+    // One floating tooltip shared by the whole report: any element carrying a `data-tip` attribute shows
+    // it on hover, faster and better-styled than a native `title`. The tip is text, never markup — a
+    // producer composes what it wants to say (see `chunkHtml`) and the mechanism stays a plain lookup.
+    var tipEl = null;
+    var tipHost = null;
+
+    function ensureTip() {
+        if (tipEl) { return tipEl; }
+        tipEl = document.createElement('div');
+        tipEl.className = 'tip';
+        tipEl.setAttribute('role', 'tooltip');
+        document.body.appendChild(tipEl);
+        return tipEl;
+    }
+
+    function showTip(text, x, y) {
+        var tip = ensureTip();
+        tip.textContent = text;
+        tip.classList.add('on');
+        moveTip(x, y);
+    }
+
+    function hideTip() {
+        tipHost = null;
+        tipEl && tipEl.classList.remove('on');
+    }
+
+    /** Follows the cursor, flipping to the other side of it near a viewport edge so it never clips. */
+    function moveTip(x, y) {
+        if (!tipEl) { return; }
+        var pad = 10;
+        var w = tipEl.offsetWidth;
+        var h = tipEl.offsetHeight;
+        var left = x + 14;
+        var top = y + 16;
+        left + w + pad > window.innerWidth && (left = x - w - 14);
+        top + h + pad > window.innerHeight && (top = y - h - 16);
+        tipEl.style.left = Math.max(pad, left) + 'px';
+        tipEl.style.top = Math.max(pad, top) + 'px';
+    }
+
+    /**
+     * Delegated once, for good: views re-render on every navigation, so binding per element (or per
+     * render) would pile up listeners on pages the user reopens all day. `mouseout` consults where the
+     * pointer went so moving between a host's own children never flickers the tip.
+     */
+    function bindTips() {
+        document.addEventListener('mouseover', function (e) {
+            var host = e.target.closest && e.target.closest('[data-tip]');
+            if (host && host !== tipHost) {
+                tipHost = host;
+                showTip(host.getAttribute('data-tip'), e.clientX, e.clientY);
+            }
+        });
+        document.addEventListener('mousemove', function (e) {
+            tipHost && moveTip(e.clientX, e.clientY);
+        });
+        document.addEventListener('mouseout', function (e) {
+            var to = e.relatedTarget;
+            tipHost && (!to || !tipHost.contains(to)) && hideTip();
+        });
+    }
+
+    /* ---------------------------------------------------------------------- copy */
+
+    /**
+     * Copies text, favouring the async Clipboard API and falling back to a hidden textarea — a report
+     * opened over `file://` is not a secure context, so `navigator.clipboard` is often absent there.
+     */
+    function copyText(text, done) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(
+                function () { done(true); },
+                function () { done(fallbackCopy(text)); },
+            );
+            return;
+        }
+        done(fallbackCopy(text));
+    }
+
+    function fallbackCopy(text) {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.top = '-1000px';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+
+        var ok = false;
+        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+        document.body.removeChild(ta);
+
+        return ok;
+    }
+
+    /** Brief acknowledgement on the button itself — a tick that took, a cross that did not. */
+    function flashCopied(btn, ok) {
+        if (btn.classList.contains('copied') || btn.classList.contains('failed')) { return; }
+        var glyph = btn.textContent;
+        btn.textContent = ok ? '✓' : '✗';
+        btn.classList.add(ok ? 'copied' : 'failed');
+        setTimeout(function () {
+            btn.textContent = glyph;
+            btn.classList.remove('copied', 'failed');
+        }, 1100);
+    }
+
+    /** Delegated once: every log row's copy button hands its row's `data-copy` to the clipboard. */
+    function bindCopy() {
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest && e.target.closest('.copy-btn');
+            if (!btn) { return; }
+            e.preventDefault();
+
+            var line = btn.closest('.line');
+            copyText(line ? (line.getAttribute('data-copy') || '') : '', function (ok) {
+                flashCopied(btn, ok);
+            });
+        });
+    }
+
     /* ----------------------------------------------------------------------- boot */
 
     function boot() {
@@ -1360,6 +1594,8 @@
 
         indexModel();
         initTheme();
+        bindTips();
+        bindCopy();
         window.addEventListener('hashchange', render);
         // The tick step is measured in pixels, so a resized window needs a fresh axis.
         window.addEventListener('resize', debounce(drawTimelineAxis, 150));

--- a/core/Output/Html/resources/assets/report.js
+++ b/core/Output/Html/resources/assets/report.js
@@ -1,0 +1,1374 @@
+/**
+ * Testo HTML report — prototype renderer.
+ *
+ * Classic IIFE script: no ES modules, no fetch, no workers — everything the `file://`
+ * origin forbids. The payload arrives as `window.TESTO_REPORT` (assets/data.js).
+ */
+(function () {
+    'use strict';
+
+    var SUPPORTED_SCHEMA_MAJOR = 1;
+
+    /* ---------------------------------------------------------------- vocabulary */
+
+    /**
+     * Every Status case of the enum, kept distinguishable: colour never carries the
+     * meaning alone — each status ships an icon and a label.
+     */
+    var STATUS = {
+        passed: {label: 'Passed', icon: '✓', order: 1},
+        failed: {label: 'Failed', icon: '✕', order: 2},
+        error: {label: 'Error', icon: '!', order: 3, textured: true},
+        risky: {label: 'Risky', icon: '▲', order: 4},
+        flaky: {label: 'Flaky', icon: '↻', order: 5},
+        skipped: {label: 'Skipped', icon: '↷', order: 6},
+        cancelled: {label: 'Cancelled', icon: '⊘', order: 7, textured: true},
+        aborted: {label: 'Aborted', icon: '■', order: 8}
+    };
+
+    /** Reading order — legend, tiles, filter chips: best outcome to worst. */
+    var STATUS_ORDER = Object.keys(STATUS).sort(function (a, b) {
+        return STATUS[a].order - STATUS[b].order;
+    });
+
+    /**
+     * Paint order of the stacked bars — a colour-safety mechanism, not cosmetics. Green beside red
+     * measures ΔE 4.1 under deuteranopia, so Passed and Failed never touch; yellow beside orange
+     * fails the normal-vision floor, so Flaky and Risky never touch either. The textured pair sits
+     * next to its own family (Cancelled by Skipped, Error by Failed), where the stripe tells them apart.
+     */
+    var BAR_ORDER = ['passed', 'flaky', 'skipped', 'cancelled', 'aborted', 'risky', 'error', 'failed'];
+
+    var TABS = [
+        {id: 'overview', label: 'Overview'},
+        {id: 'tests', label: 'Tests'},
+        {id: 'channels', label: 'Channels'},
+        {id: 'timeline', label: 'Timeline'},
+        {id: 'benches', label: 'Benches'},
+        {id: 'env', label: 'Environment'}
+    ];
+
+    /**
+     * How a channel looks is decided here rather than in the document: a report that pinned colours
+     * would freeze them into every file ever written, and a channel's identity is its name.
+     *
+     * Known channels get an icon; anything a plugin or a test invents gets a stable, name-derived colour,
+     * the same rule the terminal renderer uses.
+     */
+    var CHANNEL_PALETTE = ['#2a78d6', '#eb6834', '#1baf7a', '#eda100', '#e87ba4', '#008300', '#4a3aa7', '#e34948'];
+
+    var CHANNEL_ICONS = {
+        'stdout': '›',
+        'stderr': '!',
+        'retry': '↻',
+        'bench-result': '⏱',
+        'bench-iterations': '∷',
+        'assert-history': '✓'
+    };
+
+    var CHANNEL_COLORS = {
+        'stderr': '#d03b3b',
+        'retry': '#fab219'
+    };
+
+    /* ------------------------------------------------------------------ helpers */
+
+    function el(id) { return document.getElementById(id); }
+
+    function esc(s) {
+        return String(s === null || s === undefined ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function crc32(str) {
+        var c, crc = 0xFFFFFFFF;
+        for (var i = 0; i < str.length; i++) {
+            c = (crc ^ str.charCodeAt(i)) & 0xFF;
+            for (var k = 0; k < 8; k++) {
+                c = c & 1 ? (c >>> 1) ^ 0xEDB88320 : c >>> 1;
+            }
+            crc = (crc >>> 8) ^ c;
+        }
+        return (crc ^ 0xFFFFFFFF) >>> 0;
+    }
+
+    function dur(seconds) {
+        if (seconds === null || seconds === undefined) { return '—'; }
+        if (seconds >= 1) { return seconds.toFixed(2) + ' s'; }
+        if (seconds >= 0.001) { return (seconds * 1000).toFixed(seconds >= 0.1 ? 0 : 1) + ' ms'; }
+        return (seconds * 1000000).toFixed(0) + ' µs';
+    }
+
+    function pct(part, total) { return total > 0 ? Math.round(part / total * 1000) / 10 : 0; }
+
+    function statusChip(status, extra) {
+        var meta = STATUS[status] || {label: status, icon: '•'};
+        return '<span class="s-' + esc(status) + '" style="display:inline-flex;align-items:center;gap:6px">'
+            + '<span class="ico">' + meta.icon + '</span>'
+            + '<span style="color:var(--ink)' + (extra === 'strong' ? ';font-weight:600' : '') + '">'
+            + esc(meta.label) + '</span></span>';
+    }
+
+    function verdictChip(status) {
+        var meta = STATUS[status] || {label: status, icon: '•'};
+        return '<span class="run-verdict s-' + esc(status) + '">'
+            + '<span class="ico">' + meta.icon + '</span>' + esc(meta.label.toUpperCase()) + '</span>';
+    }
+
+    /* -------------------------------------------------------------------- model */
+
+    var report = window.TESTO_REPORT;
+    var model = {tests: [], byId: {}, suites: [], channels: {}, messages: [], benches: []};
+
+    function indexModel() {
+        (report.channels || []).forEach(function (c) {
+            model.channels[c.name] = decorateChannel(c.name, c.messages || 0);
+        });
+
+        report.suites.forEach(function (suite) {
+            model.suites.push(suite);
+            suite.cases.forEach(function (kase) {
+                kase.suite = suite;
+                kase.tests.forEach(function (test) {
+                    test.case = kase;
+                    test.suite = suite;
+                    model.tests.push(test);
+                    model.byId[test.id] = test;
+                    if (test.bench) { model.benches.push(test); }
+                    collectMessages(test, test.messages, null);
+                    (test.attempts || []).forEach(function (attempt) {
+                        collectMessages(test, attempt.messages, attempt.number);
+                    });
+                    (test.dataSets || []).forEach(function (set) {
+                        collectMessages(test, set.messages, null);
+                    });
+                });
+            });
+        });
+
+        // Stable order: by time, ties broken by insertion — a run's own order, never the arrival order.
+        model.messages.sort(function (a, b) { return a.time - b.time || a.seq - b.seq; });
+    }
+
+    function decorateChannel(name, count) {
+        return {
+            name: name,
+            icon: CHANNEL_ICONS[name] || '•',
+            color: CHANNEL_COLORS[name] || CHANNEL_PALETTE[crc32(name) % CHANNEL_PALETTE.length],
+            declared: Object.prototype.hasOwnProperty.call(CHANNEL_ICONS, name),
+            total: count,
+            count: 0
+        };
+    }
+
+    function collectMessages(test, messages, attempt) {
+        (messages || []).forEach(function (m) {
+            var channel = model.channels[m.channel]
+                || (model.channels[m.channel] = decorateChannel(m.channel, 0));
+            channel.count++;
+            model.messages.push({
+                seq: model.messages.length,
+                time: m.time,
+                channel: m.channel,
+                level: m.level,
+                content: m.content,
+                test: test,
+                attempt: attempt
+            });
+        });
+    }
+
+    function assertionsOf(test) { return (test.metrics && test.metrics.assertions) || 0; }
+
+    function groupsOf() {
+        var seen = {};
+        model.tests.forEach(function (t) { (t.groups || []).forEach(function (g) { seen[g] = true; }); });
+        return Object.keys(seen).sort();
+    }
+
+    function typesOf() {
+        var seen = {};
+        model.tests.forEach(function (t) { seen[t.type] = true; });
+        return Object.keys(seen).sort();
+    }
+
+    /* ------------------------------------------------------------------- router */
+
+    /** Filter and view state lives in the URL, so every view is linkable and shareable. */
+    var route = {tab: 'overview', test: null, params: {}};
+
+    function parseHash() {
+        var raw = location.hash.replace(/^#\/?/, '');
+        var qs = '';
+        var qi = raw.indexOf('?');
+        if (qi >= 0) { qs = raw.slice(qi + 1); raw = raw.slice(0, qi); }
+
+        var parts = raw.split('/').filter(Boolean).map(decodeURIComponent);
+        var params = {};
+        qs.split('&').filter(Boolean).forEach(function (pair) {
+            var i = pair.indexOf('=');
+            var k = decodeURIComponent(i < 0 ? pair : pair.slice(0, i));
+            params[k] = i < 0 ? '' : decodeURIComponent(pair.slice(i + 1).replace(/\+/g, ' '));
+        });
+
+        if (parts[0] === 'test' && parts[1]) {
+            return {tab: 'tests', test: parts.slice(1).join('/'), params: params};
+        }
+        var tab = parts[0] && TABS.some(function (t) { return t.id === parts[0]; }) ? parts[0] : 'overview';
+        return {tab: tab, test: null, params: params};
+    }
+
+    function href(tab, params, test) {
+        var qs = Object.keys(params || {}).filter(function (k) {
+            return params[k] !== '' && params[k] !== null && params[k] !== undefined;
+        }).map(function (k) {
+            return encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);
+        }).join('&');
+        var path = test ? 'test/' + encodeURIComponent(test) : tab;
+        return '#/' + path + (qs ? '?' + qs : '');
+    }
+
+    function go(tab, params, test) { location.hash = href(tab, params, test); }
+
+    function patchParams(patch) {
+        var next = {};
+        Object.keys(route.params).forEach(function (k) { next[k] = route.params[k]; });
+        // A query typed but not yet written back must survive a chip or a select changing around it.
+        if (liveQuery !== null) { next.q = liveQuery; }
+        Object.keys(patch).forEach(function (k) {
+            if (patch[k] === null || patch[k] === '') { delete next[k]; } else { next[k] = patch[k]; }
+        });
+        go(route.tab, next, route.test);
+    }
+
+    /* ------------------------------------------------------------------ filters */
+
+    function activeStatuses() {
+        var raw = route.params.status;
+        return raw ? raw.split(',').filter(function (s) { return STATUS[s]; }) : [];
+    }
+
+    /**
+     * The query being typed, which runs ahead of the URL: the search box filters the list in place and
+     * only writes the hash back on a debounce. Re-rendering on every keystroke would destroy the input
+     * the caret sits in — and because `hashchange` fires asynchronously, restoring focus afterwards
+     * would target an element the next render has already thrown away.
+     */
+    var liveQuery = null;
+
+    function currentQuery() {
+        return (liveQuery === null ? (route.params.q || '') : liveQuery).trim().toLowerCase();
+    }
+
+    /** Everything the free-text query searches, folded into one lowercase string per test. */
+    function haystack(test) {
+        return [test.id, test.name, test.description, test.case.name, test.file,
+            test.failure ? test.failure.message : ''].join(' ').toLowerCase();
+    }
+
+    function matches(test) {
+        var statuses = activeStatuses();
+        if (statuses.length && statuses.indexOf(test.status) < 0) { return false; }
+        if (route.params.suite && test.suite.id !== route.params.suite) { return false; }
+        if (route.params.type && test.type !== route.params.type) { return false; }
+        if (route.params.group && (test.groups || []).indexOf(route.params.group) < 0) { return false; }
+
+        var q = currentQuery();
+        return !q || haystack(test).indexOf(q) >= 0;
+    }
+
+    function filtered() { return model.tests.filter(matches); }
+
+    /* -------------------------------------------------------------- shell chrome */
+
+    function renderChrome() {
+        var run = report.run;
+        var total = totalTests();
+
+        el('verdict').innerHTML = verdictChip(run.status);
+        el('generator').textContent = 'v' + report.generator.version;
+        el('top-meta').innerHTML = ''
+            + '<span class="kv">' + esc(new Date(run.startedAt).toLocaleString()) + '</span>'
+            + '<span class="kv">wall <b>' + dur(run.duration) + '</b></span>'
+            + '<span class="kv">tests <b>' + total + '</b></span>'
+            + '<span class="kv">assertions <b>' + (run.summary.metrics.assertions || 0) + '</b></span>';
+
+        el('tabs').innerHTML = TABS.map(function (t) {
+            // The list counts rows; a data-provider test is one row that the summary counts as many.
+            var n = t.id === 'tests' ? model.tests.length
+                : t.id === 'channels' ? model.messages.length
+                    : t.id === 'benches' ? model.benches.length : null;
+            return '<a href="' + href(t.id, t.id === 'tests' ? route.params : {}) + '"'
+                + (t.id === route.tab ? ' aria-current="page"' : '') + '>' + esc(t.label)
+                + (n === null ? '' : '<span class="n">' + n + '</span>') + '</a>';
+        }).join('');
+    }
+
+    function totalTests() {
+        return report.run.summary.total;
+    }
+
+    function countsByStatus(tests) {
+        var out = {};
+        tests.forEach(function (t) { out[t.status] = (out[t.status] || 0) + 1; });
+        return out;
+    }
+
+    function stackbar(counts, total) {
+        return '<div class="stackbar">' + BAR_ORDER.filter(function (s) {
+            return counts[s];
+        }).map(function (s) {
+            return '<span class="bg-' + s + '" style="flex:' + counts[s] + '" title="'
+                + esc(STATUS[s].label + ': ' + counts[s] + ' of ' + total) + '"></span>';
+        }).join('') + '</div>';
+    }
+
+    function minibar(counts) {
+        return '<div class="minibar">' + BAR_ORDER.filter(function (s) {
+            return counts[s];
+        }).map(function (s) {
+            return '<span class="bg-' + s + '" style="flex:' + counts[s] + '" title="'
+                + esc(STATUS[s].label + ': ' + counts[s]) + '"></span>';
+        }).join('') + '</div>';
+    }
+
+    /* --------------------------------------------------------------- tab: overview */
+
+    function renderOverview() {
+        var run = report.run;
+        var counts = run.summary.counts;
+        var total = totalTests();
+
+        var html = ''
+            + '<div class="hero">'
+            + heroCell('Result', verdictChip(run.status), esc(run.status === 'passed' ? 'all green' : 'see the failures below'))
+            + heroCell('Tests', String(total), dataSetNote(total))
+            + heroCell('Wall clock', dur(run.duration), 'summed test time ' + dur(run.testDuration))
+            + heroCell('Assertions', String(run.summary.metrics.assertions || 0),
+                (Math.round((run.summary.metrics.assertions || 0) / Math.max(1, total) * 10) / 10) + ' per test')
+            + heroCell('Suites', String(report.suites.length),
+                'of ' + report.environment.config.suites.length + ' configured')
+            + '</div>'
+
+            + '<div class="grid cols-2">'
+            + card('Status breakdown', 'every case of the status enum, never reduced to pass/fail',
+                stackbar(counts, total) + statusTiles(counts, total))
+            + card('Run phases', 'wall-clock, not summed test time', phasesBlock(run))
+            + '</div>'
+
+            + '<div class="grid cols-2">'
+            + card('Slowest tests', 'top 10 by duration', slowestBlock())
+            + card('Suites', null, suitesTable())
+            + '</div>';
+
+        var notes = notesBlock();
+        if (notes !== '') {
+            html += '<div class="grid">' + card('Notes', null, notes) + '</div>';
+        }
+
+        return html;
+    }
+
+    /**
+     * A data set counts as a test in the summary but is one row in the list, so the two numbers
+     * differ on purpose — say so instead of letting the reader find the discrepancy.
+     */
+    function dataSetNote(total) {
+        var sets = 0;
+        model.tests.forEach(function (t) { sets += (t.dataSets || []).length; });
+        return sets
+            ? (total - sets) + ' tests + ' + sets + ' data sets'
+            : model.tests.length + ' in the list';
+    }
+
+    function heroCell(label, value, sub) {
+        return '<div class="cell"><div class="label">' + esc(label) + '</div>'
+            + '<div class="value">' + value + '</div>'
+            + '<div class="sub">' + sub + '</div></div>';
+    }
+
+    function card(title, hint, body) {
+        return '<section class="card">'
+            + (title ? '<header>' + esc(title) + (hint ? '<span class="hint">' + esc(hint) + '</span>' : '') + '</header>' : '')
+            + '<div class="body">' + body + '</div></section>';
+    }
+
+    /**
+     * The status tiles double as the stacked bar's legend — every slot is present even at zero, so
+     * the vocabulary is complete, and each one links to the test list filtered by that status.
+     */
+    function statusTiles(counts, total) {
+        return '<div class="tiles">' + STATUS_ORDER.map(function (s) {
+            var n = counts[s] || 0;
+            return '<a class="tile" href="' + href('tests', {status: s})
+                + '" title="filter the test list by ' + esc(STATUS[s].label) + '"'
+                + (n ? '' : ' style="opacity:.55"') + '>'
+                + '<span class="head">'
+                + '<span class="dot bg-' + s + (STATUS[s].textured ? ' textured' : '') + '"></span>'
+                + '<span class="ico s-' + s + '">' + STATUS[s].icon + '</span>'
+                + esc(STATUS[s].label) + '</span>'
+                + '<span class="num">' + n + (n ? '<span class="pct">' + pct(n, total) + '%</span>' : '')
+                + '</span></a>';
+        }).join('') + '</div>';
+    }
+
+    function phasesBlock(run) {
+        var sum = run.phases.reduce(function (a, p) { return a + p.duration; }, 0);
+        // flex-grow is the phase's share of the total: raw seconds sum to well under 1 and would leave
+        // the bar mostly empty, since grows below 1 distribute only that fraction of the free space.
+        return '<div class="phases">' + run.phases.map(function (p) {
+            return '<span style="flex:' + (sum > 0 ? p.duration / sum : 1)
+                + '" title="' + esc(p.name + ' ' + dur(p.duration)) + '"></span>';
+        }).join('') + '</div>'
+            + '<div class="legend phases-legend">' + run.phases.map(function (p) {
+                return '<span class="item"><span class="dot"></span>' + esc(p.name)
+                    + ' <b>' + dur(p.duration) + '</b></span>';
+            }).join('') + '</div>'
+            + testsSplit(run)
+            + concurrencyNote(run)
+            + '<div style="margin-top:8px;color:var(--muted);font-size:12px">phases total ' + dur(sum)
+            + ' · writing the report happens after the last phase and is counted in none of them</div>';
+    }
+
+    function phaseDuration(run, name) {
+        var p = run.phases.filter(function (x) { return x.name === name; })[0];
+        return p ? p.duration : 0;
+    }
+
+    /**
+     * The `tests` phase is not all test bodies: some of it is the pipeline around them. `execution` is
+     * the wall the bodies actually occupied (overlaps counted once), so the rest is framework overhead —
+     * the "обвязка" that summed test time cannot show on its own.
+     */
+    function testsSplit(run) {
+        if (run.execution === undefined || run.execution === null) { return ''; }
+        var overhead = Math.max(0, phaseDuration(run, 'tests') - run.execution);
+
+        return '<div class="legend phase-stats">'
+            + '<span class="item">executing <b>' + dur(run.execution) + '</b></span>'
+            + '<span class="item">pipeline overhead <b>' + dur(overhead) + '</b></span>'
+            + '</div>';
+    }
+
+    /**
+     * When tests overlap, summed test time exceeds the wall they ran on — that ratio is the concurrency
+     * boost. Stating it turns the two numbers disagreeing (which reads as a bug) into the point.
+     */
+    function concurrencyNote(run) {
+        if (!run.boost || run.boost < 1.005) { return ''; }
+
+        return '<div class="notice info" style="margin-top:12px"><span class="ico">i</span><span>'
+            + 'The tests declared <b>' + dur(run.testDuration) + '</b> of work but ran in <b>'
+            + dur(run.execution) + '</b> on the wall — a <b>×' + (Math.round(run.boost * 10) / 10)
+            + '</b> speed-up from running them concurrently. Not an error.</span></div>';
+    }
+
+    function slowestBlock() {
+        var top = model.tests.slice().sort(function (a, b) {
+            return b.duration - a.duration || a.id.localeCompare(b.id);
+        }).slice(0, 10);
+        var max = top.length ? top[0].duration : 1;
+
+        return '<div class="barlist">' + top.map(function (t) {
+            return '<div class="row">'
+                + '<a class="name" href="' + href('tests', {}, t.id) + '" title="' + esc(t.id) + '">'
+                + '<span class="ico s-' + t.status + '">' + STATUS[t.status].icon + '</span> '
+                + esc(t.case.name.split('\\').pop() + '::' + t.name) + '</a>'
+                + '<div class="val">' + dur(t.duration) + '</div>'
+                + '<div class="track"><div class="fill bg-' + t.status + '" style="width:'
+                + (t.duration / max * 100) + '%"></div></div>'
+                + '</div>';
+        }).join('') + '</div>';
+    }
+
+    function suitesTable() {
+        return '<table class="grid-table"><thead><tr>'
+            + '<th>Suite</th><th>Status</th><th>Mix</th><th class="num">Tests</th><th class="num">Duration</th>'
+            + '</tr></thead><tbody>'
+            + report.suites.map(function (suite) {
+                var tests = model.tests.filter(function (t) { return t.suite.id === suite.id; });
+                var counts = countsByStatus(tests);
+                return '<tr>'
+                    + '<td><a href="' + href('tests', {suite: suite.id}) + '">' + esc(suite.name) + '</a></td>'
+                    + '<td>' + statusChip(suite.status) + '</td>'
+                    + '<td>' + minibar(counts) + '</td>'
+                    + '<td class="num">' + tests.length + '</td>'
+                    + '<td class="num">' + dur(suite.duration) + '</td>'
+                    + '</tr>';
+            }).join('') + '</tbody></table>';
+    }
+
+    /**
+     * Empty when the run has nothing to warn about, so the card stays out of the overview.
+     */
+    function notesBlock() {
+        var truncated = model.tests.filter(function (t) { return t.truncated; });
+        if (!truncated.length) {
+            return '';
+        }
+
+        return '<div class="notice"><span class="ico">⚠</span><span>'
+            + truncated.length + ' test(s) had their channel output truncated at the configured limit. '
+            + truncated.map(function (t) {
+                return '<a href="' + href('tests', {}, t.id) + '">' + esc(t.name) + '</a>';
+            }).join(', ') + '</span></div>';
+    }
+
+    /* ------------------------------------------------------------------ tab: tests */
+
+    function renderTests() {
+        return filterBar() + '<div class="panes">'
+            + '<section class="card tree" id="tree">' + treeHtml() + '</section>'
+            + '<section class="card detail" id="detail">' + detailHtml() + '</section>'
+            + '</div>';
+    }
+
+    function filterBar() {
+        var counts = countsByStatus(model.tests);
+        var active = activeStatuses();
+
+        return '<div class="filters">'
+            + '<input type="search" id="f-q" placeholder="Search tests, files, failure messages…" value="'
+            + esc(liveQuery === null ? (route.params.q || '') : liveQuery) + '">'
+            + '<div class="chips">' + STATUS_ORDER.filter(function (s) { return counts[s]; }).map(function (s) {
+                return '<button class="chip" data-status="' + s + '" aria-pressed="'
+                    + (active.indexOf(s) >= 0) + '">'
+                    + '<span class="ico s-' + s + '">' + STATUS[s].icon + '</span>' + esc(STATUS[s].label)
+                    + '<span class="n">' + counts[s] + '</span></button>';
+            }).join('') + '</div>'
+            + select('f-suite', 'All suites', report.suites.map(function (s) { return s.id; }), route.params.suite)
+            + select('f-type', 'All types', typesOf(), route.params.type)
+            + select('f-group', 'All groups', groupsOf(), route.params.group)
+            + '<span class="count reset" id="f-count"></span>'
+            + '</div>';
+    }
+
+    function select(id, placeholder, options, value) {
+        return '<select id="' + id + '"><option value="">' + esc(placeholder) + '</option>'
+            + options.map(function (o) {
+                return '<option value="' + esc(o) + '"' + (o === value ? ' selected' : '') + '>' + esc(o) + '</option>';
+            }).join('') + '</select>';
+    }
+
+    /**
+     * The whole tree, unfiltered — {@see applyTestFilter} hides what does not match. Rendering once and
+     * filtering the DOM afterwards is what lets the search box keep the caret while it narrows the list.
+     */
+    function treeHtml() {
+        return report.suites.map(function (suite) {
+            return '<div class="suite"><div class="head">'
+                + '<span class="twisty"></span>'
+                + '<span class="ico s-' + suite.status + '">' + STATUS[suite.status].icon + '</span>'
+                + esc(suite.name)
+                + '<span class="tail" data-duration="' + esc(dur(suite.duration)) + '"></span>'
+                + '</div><div class="kids">'
+                + suite.cases.map(function (kase) {
+                    return '<div class="case"><div class="head">'
+                        + '<span class="twisty"></span>'
+                        + '<span class="ico s-' + kase.status + '">' + STATUS[kase.status].icon + '</span>'
+                        + '<span style="overflow:hidden;text-overflow:ellipsis">'
+                        + esc(shortCase(kase.name)) + '</span>'
+                        + '<span class="tail"></span>'
+                        + '</div><div class="kids tests">'
+                        + kase.tests.map(testRow).join('')
+                        + '</div></div>';
+                }).join('')
+                + '</div></div>';
+        }).join('') + '<div class="empty is-hidden" id="tree-empty">Nothing matches the filter.</div>';
+    }
+
+    /**
+     * Applies the current filter to the rendered tree: hides the rows that do not match, folds away
+     * cases and suites left with nothing, and restates the counts. Returns how many tests survived.
+     */
+    function applyTestFilter() {
+        var q = currentQuery();
+        var statuses = activeStatuses();
+        var suite = route.params.suite || '';
+        var type = route.params.type || '';
+        var group = route.params.group || '';
+        var visible = 0;
+        var facet = {};
+
+        each('#tree .test', function (row) {
+            var status = row.getAttribute('data-status');
+            // Everything but the status filter, so the chips can say how many each status would add.
+            var rest = (!suite || row.getAttribute('data-suite') === suite)
+                && (!type || row.getAttribute('data-type') === type)
+                && (!group || (' ' + row.getAttribute('data-groups') + ' ').indexOf(' ' + group + ' ') >= 0)
+                && (!q || row.getAttribute('data-hay').indexOf(q) >= 0);
+
+            rest && (facet[status] = (facet[status] || 0) + 1);
+
+            var ok = rest && (!statuses.length || statuses.indexOf(status) >= 0);
+            row.classList.toggle('is-hidden', !ok);
+            ok && visible++;
+        });
+
+        each('.filters [data-status]', function (chip) {
+            var n = facet[chip.getAttribute('data-status')] || 0;
+            var slot = chip.querySelector('.n');
+            slot && (slot.textContent = String(n));
+            chip.classList.toggle('is-zero', n === 0);
+        });
+
+        each('#tree .case', function (node) {
+            var n = node.querySelectorAll('.test:not(.is-hidden)').length;
+            node.classList.toggle('is-hidden', n === 0);
+            setTail(node, n === 0 ? '' : String(n));
+        });
+
+        each('#tree .suite', function (node) {
+            var n = node.querySelectorAll('.test:not(.is-hidden)').length;
+            node.classList.toggle('is-hidden', n === 0);
+            var tail = node.querySelector(':scope > .head > .tail');
+            tail && (tail.textContent = n === 0 ? '' : n + ' · ' + tail.getAttribute('data-duration'));
+        });
+
+        var empty = el('tree-empty');
+        empty && empty.classList.toggle('is-hidden', visible > 0);
+
+        var count = el('f-count');
+        count && (count.innerHTML = visible + ' of ' + model.tests.length
+            + (visible === model.tests.length ? ''
+                : ' · <a href="' + href('tests', {}, route.test) + '">reset</a>'));
+
+        return visible;
+    }
+
+    function setTail(node, text) {
+        var tail = node.querySelector(':scope > .head > .tail');
+        tail && (tail.textContent = text);
+    }
+
+    function each(selector, fn) {
+        Array.prototype.forEach.call(document.querySelectorAll(selector), fn);
+    }
+
+    function shortCase(name) {
+        if (name.indexOf('\\') < 0) { return name; }
+        var parts = name.split('\\');
+        return parts[parts.length - 1];
+    }
+
+    function testRow(test) {
+        var badges = [];
+        if (test.type !== 'test') { badges.push('<span class="pill">' + esc(test.type) + '</span>'); }
+        if (test.dataSets) { badges.push('<span class="pill">' + test.dataSets.length + ' sets</span>'); }
+        if (test.attempts) { badges.push('<span class="pill">' + test.attempts.length + ' attempts</span>'); }
+        if (test.bench) { badges.push('<span class="pill">bench</span>'); }
+
+        // The href stays the canonical, filter-free deep link — the shape the IDE gets and the one worth
+        // copying. A click is intercepted and carries the filters along instead.
+        return '<a class="test" href="' + href('tests', {}, test.id) + '"'
+            + ' data-test="' + esc(test.id) + '"'
+            + ' data-status="' + esc(test.status) + '"'
+            + ' data-suite="' + esc(test.suite.id) + '"'
+            + ' data-type="' + esc(test.type) + '"'
+            + ' data-groups="' + esc((test.groups || []).join(' ')) + '"'
+            + ' data-hay="' + esc(haystack(test)) + '"'
+            + (route.test === test.id ? ' aria-current="true"' : '') + '>'
+            + '<span class="spacer"></span>'
+            + '<span class="ico s-' + test.status + '" title="' + esc(STATUS[test.status].label) + '">'
+            + STATUS[test.status].icon + '</span>'
+            + '<span class="tname">' + esc(test.name) + '</span>'
+            + '<span class="badges">' + badges.join('') + '<span class="dur">' + dur(test.duration) + '</span></span>'
+            + '</a>';
+    }
+
+    function detailHtml() {
+        var test = route.test ? model.byId[route.test] : null;
+        if (!test) {
+            var visible = filtered();
+            return '<div class="empty">Pick a test on the left.<br><br>'
+                + (visible.length ? 'Deep link shape: <code>#/test/&lt;id&gt;</code> — e.g. '
+                    + '<a href="' + href('tests', {}, visible[0].id) + '">' + esc(visible[0].id) + '</a>' : '')
+                + '</div>';
+        }
+
+        var out = ''
+            + '<div class="headline">'
+            + '<div class="crumbs">' + esc(test.suite.name) + ' › ' + esc(test.case.name) + '</div>'
+            + '<h3>' + '<span class="ico s-' + test.status + '">' + STATUS[test.status].icon + '</span>'
+            + esc(test.name)
+            + (test.type !== 'test' ? '<span class="pill">' + esc(test.type) + '</span>' : '')
+            + '</h3>'
+            + (test.description ? '<div class="desc">' + esc(test.description) + '</div>' : '')
+            + '<div class="facts">'
+            + '<span>' + statusChip(test.status, 'strong') + '</span>'
+            + '<span>duration <b>' + dur(test.duration) + '</b></span>'
+            + (test.startedAt === null ? '' : '<span>started at <b>+' + dur(test.startedAt) + '</b></span>')
+            + '<span>assertions <b>' + assertionsOf(test) + '</b></span>'
+            + (test.groups && test.groups.length ? '<span>groups ' + test.groups.map(function (g) {
+                return '<a href="' + href('tests', {group: g}) + '">' + esc(g) + '</a>';
+            }).join(', ') + '</span>' : '')
+            + '<span>' + esc(test.file) + (test.line === null ? '' : ':' + test.line) + '</span>'
+            + '</div>'
+            // The exact string --filter takes back, so a reader can rerun what they are looking at.
+            + '<div class="crumbs" style="margin-top:8px">--filter=' + esc(test.filter) + '</div>'
+            + '</div>';
+
+        if (test.statusReason) {
+            out += '<div class="section"><h4>Reason</h4><div class="notice"><span class="ico s-' + test.status + '">'
+                + STATUS[test.status].icon + '</span><span>' + esc(test.statusReason) + '</span></div></div>';
+        }
+        if (test.failure) { out += '<div class="section"><h4>Failure</h4>' + failureHtml(test.failure) + '</div>'; }
+        if (test.attempts) { out += attemptsSection(test); }
+        if (test.dataSets) { out += dataSetsSection(test); }
+        if (test.bench) { out += '<div class="section"><h4>Benchmark</h4>' + benchHtml(test.bench) + '</div>'; }
+        out += outputSection(test);
+
+        return out;
+    }
+
+    function failureHtml(failure) {
+        var out = '<div class="failure">'
+            + '<div class="cls">' + esc(failure.class) + '</div>'
+            + '<div class="msg">' + esc(failure.message) + '</div>'
+            + '<div class="loc">' + esc(failure.file) + ':' + failure.line + '</div>'
+            + (failure.sourceLine
+                ? '<pre class="code">' + failure.line + ' │ ' + esc(failure.sourceLine) + '</pre>' : '')
+            + '</div>';
+
+        if (failure.diff) {
+            out += '<div style="margin-top:10px"><div class="diff">'
+                + failure.diff.lines.map(function (l) {
+                    return '<div class="l ' + esc(l.op) + '">' + esc(l.text) + '</div>';
+                }).join('') + '</div></div>';
+        }
+
+        if (failure.causedBy && failure.causedBy.length) {
+            out += '<details class="fold" style="margin-top:10px"><summary>Caused by ('
+                + failure.causedBy.length + ')</summary>'
+                + failure.causedBy.map(function (c) {
+                    return '<div class="failure" style="margin-top:8px">'
+                        + '<div class="cls">' + esc(c.class) + '</div>'
+                        + '<div class="msg">' + esc(c.message) + '</div>'
+                        + '<div class="loc">' + esc(c.file) + ':' + c.line + '</div></div>';
+                }).join('') + '</details>';
+        }
+
+        if (failure.trace && failure.trace.length) {
+            out += '<details class="fold" style="margin-top:10px" open><summary>Stack trace ('
+                + failure.trace.length + ' frames)</summary><div class="trace" style="margin-top:6px">'
+                + failure.trace.map(function (f, i) {
+                    return '<div class="frame"><span class="i">#' + i + '</span>'
+                        + '<span class="where">' + esc(f.file) + ':' + f.line
+                        + ' <span class="call">' + esc(f.call) + '</span></span></div>';
+                }).join('') + '</div></details>';
+        }
+
+        return out;
+    }
+
+    function attemptsSection(test) {
+        var policy = test.retryPolicy;
+        return '<div class="section"><h4>Attempts <span style="font-weight:400;text-transform:none;letter-spacing:0">'
+            + (policy
+                ? 'retry policy: max ' + policy.maxAttempts
+                + (policy.markFlaky ? ', marks flaky' : ', keeps the status')
+                : '')
+            + '</span></h4><div class="attempts">'
+            + test.attempts.map(function (a) {
+                var kept = a.kept;
+                return '<div class="attempt ' + (kept ? 'kept' : 'discarded') + '">'
+                    + '<div class="head">'
+                    + '<span class="ico s-' + a.status + '">' + STATUS[a.status].icon + '</span>'
+                    + '<span class="n">Attempt ' + a.number + '</span>'
+                    + '<span class="pill">' + (kept ? 'kept' : 'discarded') + '</span>'
+                    + '<span class="dur">' + dur(a.duration) + '</span>'
+                    + '</div>'
+                    + (a.failure ? '<div style="margin-top:8px">' + failureHtml(a.failure) + '</div>' : '')
+                    + (a.messages && a.messages.length
+                        ? '<details class="fold" style="margin-top:8px"><summary>Output of this attempt</summary>'
+                        + logHtml(a.messages.map(function (m) {
+                            return {time: m.time, channel: m.channel, level: m.level, content: m.content};
+                        }), false) + '</details>' : '')
+                    + '</div>';
+            }).join('') + '</div></div>';
+    }
+
+    function dataSetsSection(test) {
+        var counts = countsByStatus(test.dataSets);
+        return '<div class="section"><h4>Data sets <span style="font-weight:400">'
+            + test.dataSets.length + '</span></h4>'
+            + minibar(counts)
+            + '<table class="grid-table" style="margin-top:10px"><thead><tr>'
+            + '<th>#</th><th>Key</th><th>Arguments</th><th>Status</th><th class="num">Duration</th>'
+            + '</tr></thead><tbody>'
+            + test.dataSets.map(function (set) {
+                return '<tr>'
+                    + '<td class="num">' + (set.providerIndex !== null && set.providerIndex !== undefined
+                        ? set.providerIndex + ':' : '') + set.index + '</td>'
+                    + '<td>' + esc(set.key) + '</td>'
+                    + '<td>' + (set.arguments || []).map(function (a) {
+                        return '<span class="tag">$' + esc(a.name) + ' = ' + esc(a.value) + '</span>';
+                    }).join('') + '</td>'
+                    + '<td>' + statusChip(set.status) + '</td>'
+                    + '<td class="num">' + dur(set.duration) + '</td>'
+                    + '</tr>'
+                    + (set.failure ? '<tr><td></td><td colspan="4" style="padding-bottom:12px">'
+                        + failureHtml(set.failure) + '</td></tr>' : '');
+            }).join('') + '</tbody></table></div>';
+    }
+
+    function outputSection(test) {
+        var lines = [];
+        (test.messages || []).forEach(function (m) { lines.push(m); });
+        (test.dataSets || []).forEach(function (s) {
+            (s.messages || []).forEach(function (m) { lines.push(m); });
+        });
+
+        if (!lines.length) {
+            return '<div class="section"><h4>Channel output</h4>'
+                + '<div style="color:var(--muted);font-size:12.5px">No output recorded.</div></div>';
+        }
+
+        var counts = {};
+        lines.forEach(function (m) { counts[m.channel] = (counts[m.channel] || 0) + 1; });
+        var names = Object.keys(counts).sort();
+
+        // Channels are buttons over one list, not separate lists: pressing them narrows the merged view,
+        // hovering one previews what it would keep. Nothing pressed means everything is shown.
+        var out = '<div class="section" id="test-output"><h4>Channel output'
+            + '<span style="margin-left:auto;font-weight:400;text-transform:none;letter-spacing:0">'
+            + names.length + ' channel(s), ' + lines.length + ' message(s)</span></h4>'
+            + '<div class="chips" style="margin-bottom:10px">' + names.map(function (name) {
+                var ch = channelOf(name);
+                return '<button class="chip" data-ch-filter="' + esc(name) + '" aria-pressed="false">'
+                    + '<span class="swatch" style="width:3px;height:13px;border-radius:2px;background:'
+                    + esc(ch.color) + '"></span>'
+                    + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span>' + esc(name)
+                    + '<span class="n">' + counts[name] + '</span></button>';
+            }).join('') + '</div>'
+            + logHtml(lines, false);
+
+        if (test.truncated && test.truncated.messages) {
+            var t = test.truncated.messages;
+            out += '<div class="notice" style="margin-top:10px"><span class="ico">⚠</span><span>'
+                + 'Output truncated: showing ' + t.shown + ' of ' + t.total + ' messages ('
+                + Math.round(t.bytes / 1024) + ' KiB captured, limit ' + Math.round(t.limit / 1024)
+                + ' KiB).</span></div>';
+        }
+
+        return out + '</div>';
+    }
+
+    /** A channel from the document, or one invented on the spot for output nothing declared. */
+    function channelOf(name) {
+        return model.channels[name] || decorateChannel(name, 0);
+    }
+
+    function logHtml(lines, withTest) {
+        return '<div class="log">' + lines.map(function (m) {
+            var ch = channelOf(m.channel);
+            return '<div class="line" data-ch="' + esc(m.channel) + '">'
+                + '<span class="t">+' + m.time.toFixed(3) + '</span>'
+                + '<span class="ch"><span class="swatch" style="background:' + esc(ch.color) + '"></span>'
+                + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span>'
+                + '<span>' + esc(m.channel) + '</span>'
+                + '<span class="lv lv-' + esc(m.level) + '">' + esc(m.level) + '</span></span>'
+                + '<span class="content">' + esc(m.content.replace(/\n$/, ''))
+                + (withTest && m.test ? '<span class="from">  ← <a href="'
+                    + href('tests', {}, m.test.id) + '">' + esc(m.test.name)
+                    + (m.attempt ? ' #' + m.attempt : '') + '</a></span>' : '')
+                + '</span></div>';
+        }).join('') + '</div>';
+    }
+
+    /* --------------------------------------------------------------- tab: channels */
+
+    function renderChannels() {
+        var selected = route.params.channel || '';
+        var level = route.params.level || '';
+        var q = (route.params.q || '').toLowerCase();
+        var levels = report.levels;
+
+        // Levels arrive most severe first, so "warning and above" keeps everything at or before it.
+        var lines = model.messages.filter(function (m) {
+            if (selected && m.channel !== selected) { return false; }
+            if (level && levels.indexOf(m.level) > levels.indexOf(level)) { return false; }
+            if (q && m.content.toLowerCase().indexOf(q) < 0) { return false; }
+            return true;
+        });
+
+        var names = Object.keys(model.channels).sort();
+
+        return '<div class="filters">'
+            + '<input type="search" id="c-q" placeholder="Search output…" value="' + esc(route.params.q || '') + '">'
+            + '<div class="chips">' + levels.map(function (l) {
+                return '<button class="chip" data-level="' + l + '" aria-pressed="' + (level === l) + '">'
+                    + esc(l) + ' +</button>';
+            }).join('') + '</div>'
+            + '<span class="count reset">' + lines.length + ' of ' + model.messages.length + ' messages'
+            + (selected || level || q ? ' · <a href="' + href('channels', {}) + '">reset</a>' : '') + '</span>'
+            + '</div>'
+
+            + '<div class="panes" style="grid-template-columns:minmax(220px,260px) minmax(0,1fr)">'
+            + '<section class="card"><header>Channels</header><div class="channel-picker">'
+            + '<button data-channel="" aria-pressed="' + (selected === '') + '">'
+            + '<span class="ico">≡</span> merged view <span class="n">' + model.messages.length + '</span></button>'
+            + names.map(function (name) {
+                var ch = model.channels[name];
+                return '<button data-channel="' + esc(name) + '" aria-pressed="' + (selected === name) + '">'
+                    + '<span class="swatch" style="width:3px;height:14px;border-radius:2px;background:'
+                    + esc(ch.color) + '"></span>'
+                    + '<span style="color:' + esc(ch.color) + '">' + ch.icon + '</span> ' + esc(name)
+                    + '<span class="n">' + ch.count + '</span></button>';
+            }).join('')
+            + '</div></section>'
+
+            + '<section class="card"><header>' + (selected ? esc(selected) : 'Merged output')
+            + '<span class="hint">time is relative to the run start</span></header>'
+            + '<div class="body">' + (lines.length ? logHtml(lines, true)
+                : '<div class="empty">No messages match the filter.</div>') + '</div></section>'
+            + '</div>';
+    }
+
+    /* --------------------------------------------------------------- tab: timeline */
+
+    /** Lane magnification. 1× fits the run in the window; the rest scroll horizontally. */
+    var TL_ZOOMS = [1, 2, 4, 8, 16];
+
+    function renderTimeline() {
+        var run = report.run;
+        // The axis has to cover the last test that finished, which under concurrency can outlast the
+        // wall clock the loop measured; a shorter span would draw bars past the right edge.
+        var span = Math.max(run.duration, model.tests.reduce(function (a, t) {
+            return t.startedAt === null ? a : Math.max(a, t.startedAt + t.duration);
+        }, 0)) || 1;
+
+        // A test that never announced a start cannot be placed, and guessing a position would be a lie.
+        var rows = model.tests.filter(function (t) { return t.startedAt !== null; })
+            .sort(function (a, b) { return a.startedAt - b.startedAt || a.id.localeCompare(b.id); });
+        var unplaced = model.tests.length - rows.length;
+
+        var tools = '<div class="tl-tools"><span>Zoom</span>' + TL_ZOOMS.map(function (zoom) {
+            return '<button class="chip" data-zoom="' + zoom + '" aria-pressed="'
+                + (zoom === 1) + '">' + zoom + '×</button>';
+        }).join('') + '</div>';
+
+        return '<div class="grid">' + card('Timeline',
+            'bars are positioned by start time; overlaps are concurrency',
+            '<div class="timeline" data-span="' + span + '">'
+            + tools
+            // The axis is filled by bindTimeline(): its tick step follows the lane's pixel width,
+            // which only the laid-out element knows.
+            + '<div class="tl-scroll"><div class="tl-canvas">'
+            + '<div class="tl-head"><div class="tl-axis"></div></div>'
+            + rows.map(function (test) {
+                var left = test.startedAt / span * 100;
+                var width = Math.max(test.duration / span * 100, 0.4);
+                return '<div class="tl-row">'
+                    + '<a class="label" href="' + href('tests', {}, test.id) + '" title="' + esc(test.id) + '">'
+                    + '<span class="ico s-' + test.status + '">' + STATUS[test.status].icon + '</span> '
+                    + esc(test.name) + '</a>'
+                    + '<div class="tl-lane"><span class="bar bg-' + test.status + '" style="left:' + left
+                    + '%;width:' + width + '%" title="' + esc(test.name + ' — ' + STATUS[test.status].label
+                        + ', ' + dur(test.duration) + ' at +' + dur(test.startedAt)) + '"></span></div>'
+                    + '</div>';
+            }).join('')
+            + '</div></div></div>'
+            + (unplaced === 0 ? '' : '<div class="notice" style="margin-top:14px"><span class="ico">⚠</span>'
+                + '<span>' + unplaced + ' test(s) announced no start and cannot be placed on the timeline.'
+                + '</span></div>')
+            + '<div class="notice info" style="margin-top:14px"><span class="ico">i</span><span>'
+            + 'Wall clock <b>' + dur(run.duration) + '</b>, summed test time <b>' + dur(run.testDuration)
+            + '</b>. The excess is overlap, not double counting.</span></div>') + '</div>';
+    }
+
+    /**
+     * Ticks for a lane `laneWidth` pixels wide covering `span` seconds. The step is the smallest
+     * round unit that keeps labels ~70px apart, so zooming in subdivides the axis instead of
+     * stretching five-second gaps, and zooming out never overlaps two labels.
+     */
+    function tlTicks(span, laneWidth) {
+        var units = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 300, 600];
+        var wanted = span * 70 / Math.max(laneWidth, 1);
+        var step = units[units.length - 1];
+        for (var i = 0; i < units.length; i++) {
+            if (units[i] >= wanted) { step = units[i]; break; }
+        }
+
+        var digits = step >= 1 ? 0 : step >= 0.1 ? 1 : step >= 0.01 ? 2 : 3;
+        var out = [];
+        for (var t = 0; t <= span; t += step) {
+            out.push('<span class="tick" style="left:' + (t / span * 100) + '%">'
+                + t.toFixed(digits) + 's</span>');
+        }
+
+        return out.join('');
+    }
+
+    /* ---------------------------------------------------------------- tab: benches */
+
+    function renderBenches() {
+        if (!model.benches.length) {
+            return '<div class="grid">' + card('Benches', null, '<div class="empty">No benches in this run.</div>') + '</div>';
+        }
+        return '<div class="grid">' + model.benches.map(function (test) {
+            var calls = test.bench.cases.length ? test.bench.cases[0].calls : 0;
+            return card(test.case.name.split('\\').pop() + '::' + test.name,
+                test.bench.iterations + ' iterations × ' + calls + ' calls',
+                (test.description ? '<div style="color:var(--ink-2);margin-bottom:12px">'
+                    + esc(test.description) + '</div>' : '')
+                + benchHtml(test.bench)
+                + '<div style="margin-top:12px"><a href="' + href('tests', {}, test.id) + '">open the test →</a></div>');
+        }).join('') + '</div>';
+    }
+
+    /**
+     * Times are microseconds, the unit the bench plugin measures in. `meanDiff` is the percentage against
+     * the fastest case, which is the comparison a reader makes; the bar shows the same thing as a length.
+     */
+    function benchHtml(bench) {
+        var slowest = bench.cases.reduce(function (a, c) { return Math.max(a, c.mean); }, 1);
+        var rejected = bench.cases.some(function (c) { return c.rejected > 0; });
+
+        var out = '<table class="grid-table"><thead><tr>'
+            + '<th>Case</th><th>mean, relative</th><th class="num">mean</th>'
+            + '<th class="num">median</th><th class="num">rstdev</th><th class="num">vs fastest</th>'
+            + (rejected ? '<th class="num">rejected</th><th class="num">mean*</th>' : '')
+            + '</tr></thead><tbody>'
+            + bench.cases.map(function (c) {
+                return '<tr>'
+                    + '<td>' + esc(c.name) + (c.place === 1 ? ' <span class="pill">fastest</span>' : '') + '</td>'
+                    + '<td style="width:150px"><div class="track" style="height:8px;background:var(--grid);'
+                    + 'border-radius:4px;overflow:hidden"><div style="height:8px;border-radius:0 4px 4px 0;'
+                    + 'background:var(--accent);width:' + (c.mean / slowest * 100) + '%"></div></div></td>'
+                    + '<td class="num' + (c.place === 1 ? ' best' : '') + '">' + micros(c.mean) + '</td>'
+                    + '<td class="num">' + micros(c.median) + '</td>'
+                    + '<td class="num">±' + c.rstdev.toFixed(1) + '%</td>'
+                    + '<td class="num">' + (c.place === 1 ? '—' : '+' + c.meanDiff.toFixed(1) + '%') + '</td>'
+                    + (rejected
+                        ? '<td class="num">' + c.rejected + '</td>'
+                        + '<td class="num">' + micros(c.filteredMean) + '</td>'
+                        : '')
+                    + '</tr>';
+            }).join('') + '</tbody></table>';
+
+        if (bench.diagnostics && bench.diagnostics.length) {
+            out += '<div style="margin-top:12px;display:grid;gap:8px">'
+                + bench.diagnostics.map(function (d) {
+                    var icon = d.severity === 'danger' ? '✕' : d.severity === 'warning' ? '⚠' : 'i';
+                    return '<div class="notice' + (d.severity === 'notice' ? ' info' : '') + '">'
+                        + '<span class="ico sev-' + esc(d.severity) + '">' + icon + '</span>'
+                        + '<span><span class="sev sev-' + esc(d.severity) + '" style="font-weight:600">'
+                        + esc(d.severity) + '</span> · <code>' + esc(d.kind) + '</code> · '
+                        + esc(d.case) + ' — ' + esc(d.reason)
+                        + (d.advice ? ' <span style="color:var(--muted)">' + esc(d.advice) + '</span>' : '')
+                        + '</span></div>';
+                }).join('') + '</div>';
+        }
+
+        return out;
+    }
+
+    /** Microseconds as the bench plugin reports them, scaled to whatever reads shortest. */
+    function micros(value) {
+        if (value >= 1000000) { return (value / 1000000).toFixed(2) + ' s'; }
+        if (value >= 1000) { return (value / 1000).toFixed(2) + ' ms'; }
+        return value.toFixed(2) + ' µs';
+    }
+
+    /* -------------------------------------------------------------------- tab: env */
+
+    function renderEnv() {
+        var e = report.environment;
+        var c = e.config;
+
+        return '<div class="grid cols-2">'
+            + card('Runtime', null, '<dl class="kv-list">'
+                + kv('PHP', esc(e.php + ' (' + e.sapi + ')'))
+                + kv('Testo', esc(e.testo))
+                + kv('OS', esc(e.os))
+                + (e.cpu ? kv('CPU', esc(e.cpu)) : '')
+                + kv('Working directory', esc(e.cwd))
+                + kv('Extensions', Object.keys(e.extensions).map(function (name) {
+                    return '<span class="tag' + (e.extensions[name] ? '' : ' neg') + '">' + esc(name) + ' '
+                        + esc(e.extensions[name] || 'absent') + '</span>';
+                }).join(''))
+                + '</dl>')
+            + card('Effective run configuration', 'what this run was asked to do', '<dl class="kv-list">'
+                + kv('Config file', esc(c.file || 'none'))
+                + kv('Suites', c.suites.length
+                    ? c.suites.map(function (s) { return '<span class="tag">' + esc(s) + '</span>'; }).join('')
+                    : '<span style="color:var(--muted)">none configured</span>')
+                + kv('Options', optionTags(c.options))
+                + kv('Arguments', optionTags(c.arguments))
+                + kv('Schema version', String(report.schemaVersion))
+                + '</dl>'
+                + '<div class="notice info" style="margin-top:12px"><span class="ico">i</span><span>'
+                + 'Only the options this run was actually given are listed; the environment is never '
+                + 'recorded, so a shared report carries no tokens.</span></div>')
+            + '</div>';
+    }
+
+    /**
+     * CLI values as tags. A negated group or type (`!slow`) is a decision to exclude and reads as one.
+     */
+    function optionTags(values) {
+        var keys = Object.keys(values || {});
+        if (!keys.length) { return '<span style="color:var(--muted)">none</span>'; }
+
+        return keys.map(function (key) {
+            var value = values[key];
+            var items = Array.isArray(value) ? value : [value];
+
+            return items.map(function (item) {
+                var text = item === true ? key : key + '=' + item;
+                var negated = typeof item === 'string' && item.charAt(0) === '!';
+                return '<span class="tag' + (negated ? ' neg' : '') + '">' + esc(text) + '</span>';
+            }).join('');
+        }).join('');
+    }
+
+    function kv(k, v) { return '<dt>' + esc(k) + '</dt><dd>' + v + '</dd>'; }
+
+    /* ------------------------------------------------------------------ rendering */
+
+    function render() {
+        route = parseHash();
+        // A real navigation supersedes whatever was being typed; replaceState never gets here.
+        liveQuery = null;
+        renderChrome();
+
+        var body = el('view');
+        switch (route.tab) {
+            case 'tests': body.innerHTML = renderTests(); applyTestFilter(); break;
+            case 'channels': body.innerHTML = renderChannels(); break;
+            case 'timeline': body.innerHTML = renderTimeline(); break;
+            case 'benches': body.innerHTML = renderBenches(); break;
+            case 'env': body.innerHTML = renderEnv(); break;
+            default: body.innerHTML = renderOverview();
+        }
+
+        bindView();
+        document.title = 'Testo report — ' + report.run.status + ' · ' + totalTests() + ' tests';
+    }
+
+    function bindView() {
+        bindTestSearch();
+        bindChannelSearch();
+        bindTree();
+        bindOutputFilter();
+        bindTimeline();
+
+        bindSelect('f-suite', 'suite');
+        bindSelect('f-type', 'type');
+        bindSelect('f-group', 'group');
+
+        // Scoped to the filter bar and the channel picker on purpose. A test row carries its own
+        // data-status and data-type, so an unscoped selector makes every click on a test double as a
+        // click on the chip of that test's status.
+        each('.filters [data-status]', function (btn) {
+            btn.addEventListener('click', function () {
+                var active = activeStatuses();
+                var s = btn.getAttribute('data-status');
+                var i = active.indexOf(s);
+                if (i >= 0) { active.splice(i, 1); } else { active.push(s); }
+                patchParams({status: active.join(',')});
+            });
+        });
+
+        each('.channel-picker [data-channel]', function (btn) {
+            btn.addEventListener('click', function () {
+                patchParams({channel: btn.getAttribute('data-channel')});
+            });
+        });
+
+        each('.filters [data-level]', function (btn) {
+            btn.addEventListener('click', function () {
+                var l = btn.getAttribute('data-level');
+                patchParams({level: route.params.level === l ? '' : l});
+            });
+        });
+    }
+
+    /**
+     * The test search filters the rendered list in place and writes the query back into the hash on a
+     * debounce with `replaceState`, which does not fire `hashchange` — so nothing re-renders under the
+     * caret and the URL still carries the filter state.
+     */
+    function bindTestSearch() {
+        var input = el('f-q');
+        if (!input) { return; }
+
+        var sync = debounce(function () {
+            var params = {};
+            Object.keys(route.params).forEach(function (k) { params[k] = route.params[k]; });
+            params.q = liveQuery === '' ? null : liveQuery;
+            route.params.q = params.q === null ? undefined : params.q;
+            try {
+                history.replaceState(null, '', href(route.tab, params, route.test));
+            } catch (e) {
+                // A browser that refuses the history API over file:// just keeps the older hash.
+            }
+        }, 250);
+
+        input.addEventListener('input', function () {
+            liveQuery = input.value;
+            applyTestFilter();
+            sync();
+        });
+    }
+
+    /** The channel log is a plain re-render — there is no tree to keep, so navigation is enough. */
+    function bindChannelSearch() {
+        var input = el('c-q');
+        input && input.addEventListener('input', debounce(function () {
+            patchParams({q: input.value});
+        }, 250));
+    }
+
+    function bindTree() {
+        each('.tree .head', function (head) {
+            head.addEventListener('click', function () {
+                head.parentNode.classList.toggle('collapsed');
+            });
+        });
+
+        // Selecting a test keeps the filters that led to it, while its href stays the canonical deep link.
+        each('.tree .test', function (row) {
+            row.addEventListener('click', function (event) {
+                if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) { return; }
+                event.preventDefault();
+                go(route.tab, route.params, row.getAttribute('data-test'));
+            });
+        });
+    }
+
+    function bindOutputFilter() {
+        var root = el('test-output');
+        if (!root) { return; }
+
+        var chips = root.querySelectorAll('[data-ch-filter]');
+        var lines = root.querySelectorAll('.log .line');
+
+        function apply() {
+            var on = [];
+            Array.prototype.forEach.call(chips, function (chip) {
+                if (chip.getAttribute('aria-pressed') === 'true') { on.push(chip.getAttribute('data-ch-filter')); }
+            });
+            Array.prototype.forEach.call(lines, function (line) {
+                var keep = !on.length || on.indexOf(line.getAttribute('data-ch')) >= 0;
+                line.classList.toggle('is-hidden', !keep);
+            });
+        }
+
+        Array.prototype.forEach.call(chips, function (chip) {
+            var name = chip.getAttribute('data-ch-filter');
+
+            chip.addEventListener('click', function () {
+                chip.setAttribute('aria-pressed', chip.getAttribute('aria-pressed') === 'true' ? 'false' : 'true');
+                apply();
+            });
+
+            chip.addEventListener('mouseenter', function () {
+                Array.prototype.forEach.call(lines, function (line) {
+                    var match = line.getAttribute('data-ch') === name;
+                    line.classList.toggle('hl', match);
+                    line.classList.toggle('dim', !match);
+                });
+            });
+
+            chip.addEventListener('mouseleave', function () {
+                Array.prototype.forEach.call(lines, function (line) {
+                    line.classList.remove('hl');
+                    line.classList.remove('dim');
+                });
+            });
+        });
+    }
+
+    /**
+     * Zoom writes a CSS variable instead of re-rendering, so the horizontal scroll position and the
+     * spot the reader was looking at both survive. Only the axis is redrawn, since its tick step is a
+     * function of the lane width the zoom just changed.
+     */
+    function bindTimeline() {
+        var root = document.querySelector('.timeline');
+        if (!root) { return; }
+
+        each('.tl-tools [data-zoom]', function (btn) {
+            btn.addEventListener('click', function () {
+                root.style.setProperty('--tl-zoom', btn.getAttribute('data-zoom'));
+                each('.tl-tools [data-zoom]', function (other) {
+                    other.setAttribute('aria-pressed', String(other === btn));
+                });
+                drawTimelineAxis();
+            });
+        });
+
+        drawTimelineAxis();
+    }
+
+    /** No-op off the timeline tab, so the window resize listener can call it unconditionally. */
+    function drawTimelineAxis() {
+        var root = document.querySelector('.timeline');
+        var axis = root && root.querySelector('.tl-axis');
+        if (!axis) { return; }
+
+        axis.innerHTML = tlTicks(parseFloat(root.getAttribute('data-span')), axis.clientWidth);
+    }
+
+    function bindSelect(id, param) {
+        var s = el(id);
+        if (s) { s.addEventListener('change', function () { patchParams(makePatch(param, s.value)); }); }
+    }
+
+    function makePatch(k, v) { var p = {}; p[k] = v; return p; }
+
+    function debounce(fn, ms) {
+        var timer = null;
+        return function () {
+            clearTimeout(timer);
+            timer = setTimeout(fn, ms);
+        };
+    }
+
+    /* ---------------------------------------------------------------------- theme */
+
+    function initTheme() {
+        var stored = null;
+        try { stored = localStorage.getItem('testo-report-theme'); } catch (e) { /* file:// may deny it */ }
+        if (stored) { document.documentElement.setAttribute('data-theme', stored); }
+
+        el('theme').addEventListener('click', function () {
+            var current = document.documentElement.getAttribute('data-theme');
+            var dark = current
+                ? current === 'dark'
+                : window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var next = dark ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            try { localStorage.setItem('testo-report-theme', next); } catch (e) { /* ignore */ }
+        });
+    }
+
+    /* ----------------------------------------------------------------------- boot */
+
+    function boot() {
+        if (!report || Math.floor(report.schemaVersion) !== SUPPORTED_SCHEMA_MAJOR) {
+            document.body.innerHTML = '<div class="schema-error">'
+                + '<h2 style="margin:0 0 8px">Unsupported report schema</h2>'
+                + '<p style="margin:0">This renderer supports schema major <b>' + SUPPORTED_SCHEMA_MAJOR
+                + '</b>, the document declares <b>' + esc(report ? report.schemaVersion : 'nothing')
+                + '</b>. Refusing to render a half-broken page.</p></div>';
+            return;
+        }
+
+        indexModel();
+        initTheme();
+        window.addEventListener('hashchange', render);
+        // The tick step is measured in pixels, so a resized window needs a fresh axis.
+        window.addEventListener('resize', debounce(drawTimelineAxis, 150));
+        render();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot);
+    } else {
+        boot();
+    }
+})();

--- a/core/Output/Html/resources/index.html
+++ b/core/Output/Html/resources/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Testo report</title>
+    {{styles}}
+</head>
+<body>
+
+<header class="top">
+    <div class="top-row">
+        <span class="brand">Testo <span class="v" id="generator"></span></span>
+        <span id="verdict"></span>
+        <span class="top-meta" id="top-meta"></span>
+        <button class="theme-toggle" id="theme" type="button" title="Follows the OS preference until you pick one">
+            theme
+        </button>
+    </div>
+    <nav class="tabs" id="tabs"></nav>
+</header>
+
+<main class="shell" id="view"></main>
+
+<!-- Classic scripts and a global payload: ESM, fetch() and workers are all unavailable over file://. -->
+{{scripts}}
+</body>
+</html>

--- a/docs/spec/events-naming.md
+++ b/docs/spec/events-naming.md
@@ -245,6 +245,6 @@ this one. The payload is the same card for all of them: `Testo\Core\Report\Repor
 as `$event->info`, holding the format, the label and a `Stringable` location — a `Path` for a file, a URL
 for a report published to a service.
 
-Any reporter dispatches them — JUnit XML and the `--log-json` file — and the renderer that owns stdout
-decides how to state them. A reporter that printed its own path instead would have to know which
-renderer is active.
+Any reporter dispatches them — the HTML report, JUnit XML, the `--log-json` file, each coverage report —
+and the renderer that owns stdout decides how to state them. A reporter that printed its own path
+instead would have to know which renderer is active.

--- a/skills/testo-configure/SKILL.md
+++ b/skills/testo-configure/SKILL.md
@@ -135,6 +135,27 @@ Notes on the example:
 - `CodecovPlugin` is application-wide → it applies to every suite.
 - Names are arbitrary; keep them short — they appear in CI logs and in `--suite=`.
 
+## Reports on every run
+
+Output plugins are application-wide. Add them to `plugins:` when a report should be produced by every run
+rather than only when a flag asks for it:
+
+```php
+use Testo\Output\Html\HtmlPlugin;
+use Testo\Output\JUnit\JUnitPlugin;
+
+plugins: [
+    // runtime/report/index.html; a path ending in .html inlines everything into that one file instead
+    new HtmlPlugin(),
+    new JUnitPlugin(__DIR__ . '/build/junit.xml'),
+],
+```
+
+`HtmlPlugin` takes a second path for the report's own JSON document
+(`new HtmlPlugin('runtime/report', 'runtime/report.json')`) — the HTML is a view over that
+document, and CI or external tooling can consume it on its own. The HTML report opens over `file://`
+with no server and reaches no network.
+
 ## Conditional / dynamic config
 
 Because `testo.php` is real PHP, conditional logic is fine:
@@ -176,6 +197,9 @@ vendor/bin/testo --coverage-xml=build/coverage-xml         # write coverage XML 
 vendor/bin/testo --teamcity            # TeamCity output (CI/IDE)
 vendor/bin/testo --json                # minimal JSON on stdout: run summary + failed tests (for LLM agents / CI scripts)
 vendor/bin/testo --log-json=build/report.json  # same JSON to a file, keeps the terminal output (like --log-junit)
+vendor/bin/testo --log-html=runtime/report        # self-contained HTML report: directory with index.html + assets
+vendor/bin/testo --log-html=build/report.html     # ...or a single inlined file, chosen by the .html extension
+vendor/bin/testo --log-report=build/report.json   # the full run as a versioned JSON document (data behind the HTML)
 vendor/bin/testo --config=path/to/testo.php
 ```
 

--- a/tests/Application/Feature/Runner/RunPhasesTest.php
+++ b/tests/Application/Feature/Runner/RunPhasesTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Feature\Runner;
+
+use Internal\Path;
+use Testo\Application\Application;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\RunConfiguration;
+use Testo\Application\Config\SuiteConfig;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Context\RunResult;
+use Testo\Test;
+
+/**
+ * Where a run spent its time, and what it was asked to do — the two things a report cannot derive from
+ * results alone. Phases are accumulated durations rather than intervals, because discovery and
+ * execution interleave: a suite is scanned, run, and only then is the next one scanned.
+ */
+#[Test]
+#[Covers(Application::class)]
+#[Covers(RunConfiguration::class)]
+final class RunPhasesTest
+{
+    public function aRunReportsEveryPhaseInTheOrderItBegan(): void
+    {
+        $timing = self::run()->timing;
+
+        Assert::same(\array_keys($timing->phases()), ['startup', 'discovery', 'tests', 'teardown']);
+
+        // A real run bootstrapped before the loop and executed tests inside it.
+        Assert::true($timing->startup > 0.0);
+        Assert::true($timing->tests > 0.0);
+    }
+
+    public function theSuiteLoopFitsInsideTheWholeRun(): void
+    {
+        $timing = self::run()->timing;
+
+        // The loop (discovery + execution) is bracketed by startup before it and teardown after, both
+        // measured and non-negative, so it cannot exceed the whole run.
+        Assert::true(
+            $timing->duration() <= $timing->total(),
+            \sprintf('duration = %f, total = %f', $timing->duration(), $timing->total()),
+        );
+    }
+
+    public function anApplicationBuiltFromAConfigObjectStillOffersARunConfiguration(): void
+    {
+        $app = self::app();
+
+        // No command line was involved, so there is nothing to report — but a reporter must not have to
+        // ask whether the service exists.
+        $config = $app->getContainer()->get(RunConfiguration::class);
+        Assert::same($config->configFile, null);
+        Assert::same($config->options, []);
+    }
+
+    public function inputIsCarriedAsGivenWhileTheEnvironmentIsLeftOut(): void
+    {
+        $app = Application::createFromInput(
+            configFile: Path::create(__FILE__),
+            inputOptions: ['group' => ['db'], 'json' => false, 'filter' => []],
+            inputArguments: ['path' => 'tests/Unit'],
+            environment: ['SECRET_TOKEN' => 'do-not-report-me'],
+        );
+
+        $config = $app->getContainer()->get(RunConfiguration::class);
+
+        Assert::same((string) $config->configFile, (string) Path::create(__FILE__));
+        Assert::same($config->option('group'), ['db']);
+        Assert::same($config->arguments['path'], 'tests/Unit');
+
+        // A switched-off flag and an empty array are defaults, not decisions, and listing them would
+        // describe a run that never happened.
+        Assert::same(\array_keys($config->givenOptions()), ['group']);
+
+        // A report is committed, attached to CI builds and opened by whoever has the link, so the
+        // environment the process was handed never enters it.
+        Assert::string(\print_r($config, true))->notContains('do-not-report-me');
+    }
+
+    private static function app(): Application
+    {
+        return Application::createFromConfig(new ApplicationConfig(
+            src: [],
+            suites: [
+                new SuiteConfig(
+                    'Phases',
+                    location: new FinderConfig(include: [__DIR__ . '/../../Stub/Runner']),
+                ),
+            ],
+        ));
+    }
+
+    private static function run(): RunResult
+    {
+        return self::app()->run();
+    }
+}

--- a/tests/Output/Feature/Html/ReportGenerationTest.php
+++ b/tests/Output/Feature/Html/ReportGenerationTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Feature\Html;
+
+use Internal\Path;
+use Testo\Application\Application;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\Plugin\ApplicationPlugins;
+use Testo\Application\Config\SuiteConfig;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Event\Report\ReportFileGenerated;
+use Testo\Event\Report\ReportFileGenerating;
+use Testo\Output\Html\HtmlPlugin;
+use Testo\Test;
+use Tests\Output\Stub\Html\ReportSpyPlugin;
+
+/**
+ * A whole run through the reporter: what lands on disk, in which layout, and what the run tells the rest
+ * of the world about it.
+ *
+ * The hard constraint is that the report opens over `file://` with no server, which forbids more than
+ * fetching — XHR on local files, ES modules, dynamic `import()` and workers are all unavailable because
+ * the origin is `null`. That is a property of the written files, so it is asserted on them.
+ */
+#[Test]
+#[Covers(HtmlPlugin::class)]
+final class ReportGenerationTest
+{
+    public function aDirectoryReportIsWrittenWithRelativeAssetsAndAnnouncedByItsEntryFile(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => new HtmlPlugin($path . '/report'),
+            static function (string $directory, array $reports): void {
+                $entry = $directory . '/report/index.html';
+                Assert::true(\is_file($entry), $entry);
+                Assert::true(\is_file($directory . '/report/assets/report.css'));
+                Assert::true(\is_file($directory . '/report/assets/report.js'));
+                Assert::true(\is_file($directory . '/report/assets/data.js'));
+
+                $html = (string) \file_get_contents($entry);
+
+                // Relative paths and classic scripts: an absolute path or a module would leave the report
+                // working only on the machine that wrote it, or not at all.
+                Assert::string($html)->contains('href="assets/report.css"');
+                Assert::string($html)->contains('<script src="assets/data.js"></script>');
+                Assert::string($html)->notContains('type="module"');
+                Assert::string($html)->notContains('http://');
+                Assert::string($html)->notContains('https://');
+
+                // The data is a script assigning a global, because fetching a local file is exactly what a
+                // null origin forbids.
+                Assert::string((string) \file_get_contents($directory . '/report/assets/data.js'))
+                    ->contains('window.TESTO_REPORT = {');
+
+                // The announcement points at the entry file, never at the directory, so a consumer opens
+                // it without having to know the layout.
+                Assert::same(\count($reports), 1);
+                Assert::same($reports[0]->info->format, 'html');
+                Assert::string((string) $reports[0]->info->path)->contains('report/index.html');
+            },
+        );
+    }
+
+    public function anHtmlDestinationInlinesEverythingIntoOneFile(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => new HtmlPlugin($path . '/single.html'),
+            static function (string $directory, array $reports): void {
+                $file = $directory . '/single.html';
+                Assert::true(\is_file($file));
+                Assert::false(\is_dir($directory . '/assets'));
+
+                $html = (string) \file_get_contents($file);
+
+                // Nothing left to load means none of the file:// restrictions apply at all.
+                Assert::string($html)->contains('window.TESTO_REPORT = {');
+                Assert::string($html)->contains('<style>');
+                Assert::string($html)->notContains('src="assets/');
+                Assert::string($html)->notContains('href="assets/');
+
+                Assert::same(\count($reports), 1);
+                Assert::string((string) $reports[0]->info->path)->contains('single.html');
+            },
+        );
+    }
+
+    public function theDocumentIsAlsoWrittenOnItsOwn(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => new HtmlPlugin(null, $path . '/report.json'),
+            static function (string $directory, array $reports): void {
+                $file = $directory . '/report.json';
+                Assert::true(\is_file($file));
+
+                $document = self::read($file);
+
+                // The report is a view over the data; the data is an artifact in its own right, so it is
+                // announced as its own format rather than as a side effect of the page.
+                Assert::same($document['schemaVersion'], 1);
+                Assert::same($document['run']['status'], 'passed');
+                Assert::same($document['run']['summary']['total'], 1);
+                Assert::same(\count($reports), 1);
+                // Its own id, not a bare `json`: the run summary `--log-json` writes is JSON too, and a
+                // consumer switching on the format has to be able to tell the two schemas apart.
+                Assert::same($reports[0]->info->format, 'testo-report');
+            },
+        );
+    }
+
+    public function theRunItDescribesIsTheOneThatHappened(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => new HtmlPlugin(null, $path . '/report.json'),
+            static function (string $directory, array $reports): void {
+                $document = self::read($directory . '/report.json');
+                $test = $document['suites'][0]['cases'][0]['tests'][0];
+
+                Assert::same($test['name'], 'itPrintsAndPasses');
+                Assert::same($test['status'], 'passed');
+                Assert::same($test['metrics']['assertions'], 1);
+                // Phases are measured by the application, not guessed by the reporter.
+                Assert::same(\array_column($document['run']['phases'], 'name'), [
+                    'startup', 'discovery', 'tests', 'teardown',
+                ]);
+                // The test began somewhere inside the run — what a timeline needs and a result cannot say.
+                Assert::true($test['startedAt'] >= 0.0);
+                Assert::string((string) \json_encode($test['messages']))->contains('from the test');
+            },
+        );
+    }
+
+    public function aReportIsAnnouncedWhenTheRunStartsAndAgainOnceItIsWritten(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => new HtmlPlugin($path . '/report'),
+            static function (string $directory, array $reports): void {
+                Assert::same(ReportSpyPlugin::sequence(), [
+                    ReportFileGenerating::class,
+                    ReportFileGenerated::class,
+                ]);
+
+                // The first announcement lands while the run's output is still open — no suite has closed
+                // yet — because a `testoReport` service message after the last `testSuiteFinished` has no
+                // node in an IDE's run tree to attach to.
+                Assert::same(ReportSpyPlugin::$seen[0]['suitesFinished'], 0);
+                Assert::same(ReportSpyPlugin::$seen[1]['suitesFinished'], 1);
+
+                // A promise first, a fact second: nothing is readable at the announced path until the run
+                // is over, so only the later event means the report can be opened.
+                Assert::false(ReportSpyPlugin::$seen[0]['existed']);
+                Assert::true(ReportSpyPlugin::$seen[1]['existed']);
+
+                // Both name the same entry file, so a consumer of the early one has nothing to correct.
+                Assert::same(
+                    (string) ReportSpyPlugin::$seen[0]['event']->info->path,
+                    (string) ReportSpyPlugin::$seen[1]['event']->info->path,
+                );
+                Assert::string((string) $reports[0]->info->path)->contains('report/index.html');
+            },
+        );
+    }
+
+    public function anInertReporterWritesNothing(): void
+    {
+        self::inReport(
+            static fn(string $path): HtmlPlugin => HtmlPlugin::inert(),
+            static function (string $directory, array $reports): void {
+                // The application defaults hold an inert copy so the CLI flags have something to activate;
+                // a project that passes no flag must end up with no files.
+                Assert::same(\array_diff((array) \scandir($directory), ['.', '..']), []);
+                Assert::same($reports, []);
+            },
+        );
+    }
+
+    /**
+     * Runs one stub suite with the reporter the factory builds for a fresh temporary directory, hands the
+     * directory and everything the run announced to the assertions, and clears the directory afterwards.
+     *
+     * @param \Closure(string): HtmlPlugin $reporter
+     * @param \Closure(string, list<ReportFileGenerated>): void $assertions
+     */
+    private static function inReport(\Closure $reporter, \Closure $assertions): void
+    {
+        $directory = \sys_get_temp_dir() . '/testo-html-report-' . \bin2hex(\random_bytes(6));
+        \mkdir($directory, 0o777, true);
+
+        ReportSpyPlugin::reset();
+
+        try {
+            Application::createFromConfig(new ApplicationConfig(
+                src: [],
+                suites: [
+                    new SuiteConfig(
+                        'Output/Stub',
+                        location: new FinderConfig(include: [\dirname(__DIR__, 2) . '/Stub/Html/Run']),
+                    ),
+                ],
+                plugins: ApplicationPlugins::without(HtmlPlugin::class)->with(
+                    $reporter($directory),
+                    new ReportSpyPlugin(),
+                ),
+            ))->run();
+
+            $assertions($directory, ReportSpyPlugin::generated());
+        } finally {
+            self::remove(Path::create($directory));
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function read(string $file): array
+    {
+        /** @var array<string, mixed> */
+        return \json_decode((string) \file_get_contents($file), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    private static function remove(Path $path): void
+    {
+        $target = (string) $path;
+
+        if (\is_dir($target)) {
+            foreach (\array_diff((array) \scandir($target), ['.', '..']) as $entry) {
+                self::remove($path->join((string) $entry));
+            }
+            \rmdir($target);
+            return;
+        }
+
+        \is_file($target) and \unlink($target);
+    }
+}

--- a/tests/Output/Stub/Html/ReportSpyPlugin.php
+++ b/tests/Output/Stub/Html/ReportSpyPlugin.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\Html;
+
+use Internal\Container\Container;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Event\Report\ReportFileGenerated;
+use Testo\Event\Report\ReportFileGenerating;
+use Testo\Event\TestSuite\TestSuiteFinished;
+
+/**
+ * Collects every report announcement a run makes, so a test can check what the reporter told the rest of
+ * the world rather than only what it left on disk.
+ *
+ * One closure serves both moments, subscribed once per event: the path is what this records, and only the
+ * file events have one. Each entry states whether the file was there when the event arrived — the
+ * difference between announcing a promise and announcing a fact — and how many suites had already
+ * finished, which is what pins the early announcement inside the run's still-open output.
+ */
+final class ReportSpyPlugin implements PluginConfigurator
+{
+    /**
+     * @var list<array{
+     *     event: ReportFileGenerating|ReportFileGenerated,
+     *     existed: bool,
+     *     suitesFinished: int
+     * }>
+     */
+    public static array $seen = [];
+
+    private static int $suitesFinished = 0;
+
+    public static function reset(): void
+    {
+        self::$seen = [];
+        self::$suitesFinished = 0;
+    }
+
+    /**
+     * @return list<ReportFileGenerated>
+     */
+    public static function generated(): array
+    {
+        $written = [];
+        foreach (self::$seen as $entry) {
+            $entry['event'] instanceof ReportFileGenerated and $written[] = $entry['event'];
+        }
+
+        return $written;
+    }
+
+    /**
+     * @return list<class-string<ReportFileGenerating|ReportFileGenerated>>
+     */
+    public static function sequence(): array
+    {
+        return \array_map(
+            static fn(array $entry): string => $entry['event']::class,
+            self::$seen,
+        );
+    }
+
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $listeners = $container->get(EventListenerCollector::class);
+
+        $record = static function (ReportFileGenerating|ReportFileGenerated $event): void {
+            self::$seen[] = [
+                'event' => $event,
+                'existed' => \is_file((string) $event->info->path),
+                'suitesFinished' => self::$suitesFinished,
+            ];
+        };
+
+        $listeners->addListener(ReportFileGenerating::class, $record);
+        $listeners->addListener(ReportFileGenerated::class, $record);
+
+        $listeners->addListener(
+            TestSuiteFinished::class,
+            static function (): void {
+                ++self::$suitesFinished;
+            },
+        );
+    }
+}

--- a/tests/Output/Stub/Html/Run/PassingCase.php
+++ b/tests/Output/Stub/Html/Run/PassingCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\Html\Run;
+
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * A minimal case for the feature tests to run: one test that passes, prints, and asserts something, so a
+ * generated report has a suite, a case, a test, an assertion count and channel output to describe.
+ */
+#[Test]
+final class PassingCase
+{
+    public function itPrintsAndPasses(): void
+    {
+        echo "from the test\n";
+
+        Assert::true(true);
+    }
+}

--- a/tests/Output/Stub/Html/SampleTestClass.php
+++ b/tests/Output/Stub/Html/SampleTestClass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Stub\Html;
+
+use Testo\Filter\Group;
+
+/**
+ * Methods the document tests build results around. Nothing here is ever executed — only reflected on,
+ * which is where the report reads a test's line number, parameter names and groups from.
+ */
+#[Group('reporting')]
+final class SampleTestClass
+{
+    public function passingTest(): void {}
+
+    #[Group('failure')]
+    public function failingTest(): void {}
+
+    public function datasetTest(string $input, int $expected): void {}
+
+    public function flakyTest(): void {}
+}

--- a/tests/Output/Unit/Html/DocumentBuilderTest.php
+++ b/tests/Output/Unit/Html/DocumentBuilderTest.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Html;
+
+use Internal\Path;
+use Testo\Application\Config\RunConfiguration;
+use Testo\Application\Internal\EventDispatcher;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\CaseResult;
+use Testo\Core\Context\Identity\SuiteIdentity;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteResult;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Log\Level;
+use Testo\Core\Log\Message;
+use Testo\Core\Log\MessageLog;
+use Testo\Core\Value\RunTiming;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\Summary;
+use Testo\Data\MultipleResult;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Test\TestDataSetStarting;
+use Testo\Event\Test\TestPipelineStarting;
+use Testo\Event\Test\TestRetrying;
+use Testo\Output\Html\Internal\DocumentBuilder;
+use Testo\Output\Html\Internal\Json;
+use Testo\Output\Html\Internal\Recorder;
+use Testo\Test;
+use Tests\Output\Stub\Html\SampleTestClass;
+
+/**
+ * The report document: what it says about a run, and the two properties a consumer relies on — every
+ * status is present, and the same run always encodes to the same bytes.
+ */
+#[Test]
+#[Covers(DocumentBuilder::class)]
+#[Covers(Recorder::class)]
+final class DocumentBuilderTest
+{
+    public function theDocumentOpensWithItsSchemaVersion(): void
+    {
+        $document = self::build();
+
+        // A consumer reads the version before anything else, and refuses a major it does not know rather
+        // than rendering half a page — so the field cannot be somewhere in the middle.
+        Assert::same(\array_key_first($document), 'schemaVersion');
+        Assert::same($document['schemaVersion'], 1);
+        Assert::same(\array_keys($document), [
+            'schemaVersion', 'generator', 'run', 'environment', 'channels', 'levels', 'suites',
+        ]);
+    }
+
+    public function everyStatusIsCountedIncludingTheOnesThatCountedNothing(): void
+    {
+        $document = self::build();
+
+        // Insertion order would be whatever order tests finished in, which concurrency makes unstable;
+        // the enum order is the same in every report. Zeros stay so a filter knows the status exists.
+        Assert::same(\array_keys($document['run']['summary']['counts']), [
+            'passed', 'failed', 'skipped', 'error', 'risky', 'flaky', 'cancelled', 'aborted',
+        ]);
+        Assert::same($document['run']['summary']['counts']['passed'], 2);
+        Assert::same($document['run']['summary']['counts']['failed'], 1);
+        Assert::same($document['run']['summary']['counts']['risky'], 0);
+    }
+
+    public function theRunSplitsExecutionFromPipelineOverheadAndStatesTheBoost(): void
+    {
+        $run = self::build()['run'];
+
+        // Execution is the wall the bodies occupied (overlaps once); overhead is the tests phase minus it.
+        // Both are non-negative, and declared work over execution — the boost — is at least 1.
+        Assert::true($run['execution'] >= 0.0, "execution = {$run['execution']}");
+        Assert::true($run['overhead'] >= 0.0, "overhead = {$run['overhead']}");
+        Assert::true(
+            $run['boost'] === null || $run['boost'] >= 1.0 - 1e-9,
+            'boost = ' . \var_export($run['boost'], true),
+        );
+    }
+
+    public function aRunEncodesToTheSameBytesEveryTime(): void
+    {
+        $recorder = new Recorder();
+        $result = self::runResult(self::dispatcher($recorder));
+
+        $first = self::builder($recorder)->build($result);
+        $second = self::builder($recorder)->build($result);
+
+        // Reports have to be diffable and testable with golden files, which rules out anything stamped
+        // from the clock while building and any map left in insertion order.
+        Assert::same(Json::artifact($first), Json::artifact($second));
+    }
+
+    public function aTestNamesTheFilterThatSelectsItAgain(): void
+    {
+        $test = self::firstTest(self::build());
+
+        Assert::same($test['filter'], SampleTestClass::class . '::passingTest');
+        Assert::same($test['id'], 'Output/Unit::' . SampleTestClass::class . '::passingTest');
+    }
+
+    public function groupsAreCollectedFromTheClassAndTheMethodAndSorted(): void
+    {
+        $document = self::build();
+        $failing = $document['suites'][0]['cases'][0]['tests'][1];
+
+        // The union of what the method and the class declare — the same set `--group` selects on — and in
+        // a stated order, because the traversal's own order says nothing.
+        Assert::same($failing['groups'], ['failure', 'reporting']);
+    }
+
+    public function messageTimesAreOffsetsFromTheRunStart(): void
+    {
+        $test = self::firstTest(self::build());
+
+        // Absolute timestamps would make two runs of the same code produce different documents, and a
+        // reader compares messages against each other rather than against the wall clock.
+        Assert::same(\count($test['messages']), 2);
+        Assert::true($test['messages'][0]['time'] < 1.0, (string) $test['messages'][0]['time']);
+        Assert::same($test['messages'][0]['channel'], 'stdout');
+        Assert::same($test['messages'][1]['level'], 'error');
+    }
+
+    public function channelOutputIsCappedAndTheCutIsStated(): void
+    {
+        $document = self::build(messageLimit: 8);
+        $test = self::firstTest($document);
+
+        // Output is the one part of a run with no natural size, so it is capped — and a report that cut
+        // something must say so, or it reads as a test that printed less than it did.
+        Assert::same($test['truncated']['messages']['total'], 2);
+        Assert::same($test['truncated']['messages']['limit'], 8);
+        Assert::true($test['truncated']['messages']['bytes'] > 8);
+    }
+
+    public function dataSetsCarryTheirCoordinatesLabelAndArguments(): void
+    {
+        $document = self::build();
+        $sets = $document['suites'][0]['cases'][0]['tests'][2]['dataSets'];
+
+        Assert::same(\count($sets), 1);
+        Assert::same($sets[0]['providerIndex'], 0);
+        Assert::same($sets[0]['index'], 1);
+        // Addressed by index, labelled by key: provider keys are free to repeat.
+        Assert::same($sets[0]['key'], 'a string');
+        Assert::same($sets[0]['arguments'], [
+            ['name' => 'input', 'type' => 'string', 'value' => "'x'"],
+            ['name' => 'expected', 'type' => 'int', 'value' => '42'],
+        ]);
+    }
+
+    public function attemptsAreListedOldestFirstWithTheKeptOneLast(): void
+    {
+        $document = self::build();
+        $attempts = $document['suites'][0]['cases'][0]['tests'][3]['attempts'];
+
+        // The retry interceptor returns the last attempt and drops the rest; without the discarded ones a
+        // flaky test looks like it simply passed.
+        Assert::same(\count($attempts), 2);
+        Assert::same($attempts[0]['number'], 1);
+        Assert::false($attempts[0]['kept']);
+        Assert::same($attempts[0]['status'], 'failed');
+        Assert::true(isset($attempts[0]['failure']));
+        Assert::true($attempts[1]['kept']);
+        Assert::same($attempts[1]['status'], 'flaky');
+    }
+
+    public function aFailureCarriesItsLocationSourceLineAndTrace(): void
+    {
+        $failure = self::build()['suites'][0]['cases'][0]['tests'][1]['failure'];
+
+        Assert::same($failure['class'], \RuntimeException::class);
+        Assert::same($failure['message'], 'boom');
+        Assert::string($failure['file'])->contains('DocumentBuilderTest.php');
+        // The line the failure points at, read back from the file — the one thing a stack frame cannot say.
+        Assert::string($failure['sourceLine'])->contains('boom');
+        Assert::true($failure['trace'] !== []);
+    }
+
+    public function theEnvironmentStatesTheInputButNeverTheEnvironmentVariables(): void
+    {
+        $document = self::build();
+        $config = $document['environment']['config'];
+
+        Assert::same($config['options'], ['group' => ['db']]);
+        Assert::same($config['suites'], ['Output/Unit', 'Output/Feature']);
+        // A report gets committed and shared; the process environment must not travel with it.
+        Assert::string(Json::artifact($document))->notContains('do-not-report-me');
+    }
+
+    public function channelsAreListedWithCountsAndNoPresentation(): void
+    {
+        $channels = self::build()['channels'];
+
+        // Names and counts only: how a channel looks is the renderer's business, and a document that
+        // pinned colours would freeze them into every report ever written.
+        Assert::same($channels, [
+            ['name' => 'stderr', 'messages' => 1],
+            ['name' => 'stdout', 'messages' => 1],
+        ]);
+    }
+
+    /**
+     * @param int<0, max> $messageLimit
+     * @return array<non-empty-string, mixed>
+     */
+    private static function build(int $messageLimit = 65536): array
+    {
+        $recorder = new Recorder();
+        $result = self::runResult(self::dispatcher($recorder));
+
+        return self::builder($recorder, $messageLimit)->build($result);
+    }
+
+    /**
+     * @param int<0, max> $messageLimit
+     */
+    private static function builder(Recorder $recorder, int $messageLimit = 65536): DocumentBuilder
+    {
+        return new DocumentBuilder(
+            recorder: $recorder,
+            config: new RunConfiguration(
+                configFile: Path::create('testo.php'),
+                options: ['group' => ['db'], 'json' => false],
+                arguments: [],
+            ),
+            messageLimit: $messageLimit,
+            suiteNames: ['Output/Unit', 'Output/Feature'],
+        );
+    }
+
+    private static function dispatcher(Recorder $recorder): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+        $recorder->configure($dispatcher);
+        $dispatcher->dispatch(new SessionStarting());
+
+        return $dispatcher;
+    }
+
+    /**
+     * One suite with one case holding four tests: a passing one with output, a failing one, a data
+     * provider, and a flaky one that needed two attempts.
+     */
+    private static function runResult(EventDispatcher $dispatcher): RunResult
+    {
+        $passing = self::start($dispatcher, 'passingTest');
+        $failing = self::start($dispatcher, 'failingTest');
+        $dataset = self::start($dispatcher, 'datasetTest');
+        $flaky = self::start($dispatcher, 'flakyTest');
+
+        $tests = [
+            new TestResult(
+                info: $passing,
+                status: Status::Passed,
+                messages: new MessageLog([
+                    new Message(\microtime(true), 'stdout', Level::Info, "hello\n"),
+                    new Message(\microtime(true), 'stderr', Level::Error, "a warning\n"),
+                ]),
+                summary: Summary::forTest(Status::Passed, 0.01)->withAddedMetric('assertions', 3),
+            ),
+            new TestResult(
+                info: $failing,
+                status: Status::Failed,
+                failure: new \RuntimeException('boom'),
+                summary: Summary::forTest(Status::Failed, 0.02),
+            ),
+            self::dataProviderResult($dispatcher, $dataset),
+            self::flakyResult($dispatcher, $flaky),
+        ];
+
+        $case = new CaseResult(
+            $tests,
+            status: Status::Failed,
+            summary: Summary::combine(\array_map(
+                static fn(TestResult $r): Summary => $r->summary,
+                $tests,
+            )),
+        );
+        $suite = new SuiteResult([$case], status: Status::Failed, summary: $case->summary);
+
+        return new RunResult(
+            [$suite],
+            status: Status::Failed,
+            summary: $suite->summary,
+            timing: new RunTiming(startup: 0.1, discovery: 0.2, tests: 0.15, teardown: 0.05),
+        );
+    }
+
+    private static function dataProviderResult(EventDispatcher $dispatcher, TestInfo $info): TestResult
+    {
+        $set = $info->with(
+            arguments: ['x', 42],
+            identity: $info->identity->toDataSet(dataProvider: 0, dataSet: 1),
+        );
+
+        # A data set's label lives on the event and nowhere else: the address carries indexes, on purpose,
+        # because provider keys are free to repeat.
+        $dispatcher->dispatch(new TestDataSetStarting($set, 'a string', 0, 1));
+
+        $setResult = new TestResult(
+            info: $set,
+            status: Status::Passed,
+            summary: Summary::forTest(Status::Passed, 0.005)->withAddedMetric('assertions', 1),
+        );
+        $multiple = new MultipleResult([$setResult]);
+
+        return new TestResult(
+            info: $info,
+            status: Status::Passed,
+            result: $multiple,
+            attributes: [MultipleResult::class => $multiple],
+            summary: $setResult->summary,
+        );
+    }
+
+    private static function flakyResult(EventDispatcher $dispatcher, TestInfo $info): TestResult
+    {
+        $dispatcher->dispatch(new TestRetrying(
+            $info,
+            2,
+            new TestResult(
+                info: $info,
+                status: Status::Failed,
+                failure: new \RuntimeException('flaky boom'),
+                summary: Summary::forTest(Status::Failed, 0.03),
+            ),
+        ));
+
+        return new TestResult(
+            info: $info,
+            status: Status::Flaky,
+            summary: Summary::forTest(Status::Flaky, 0.04),
+        );
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private static function start(EventDispatcher $dispatcher, string $method): TestInfo
+    {
+        $info = self::makeTestInfo($method);
+        # The report reads a test's start from the pipeline event: a finished result knows how long it took
+        # but not when it began, and without that there is no timeline.
+        $dispatcher->dispatch(new TestPipelineStarting($info));
+
+        return $info;
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private static function makeTestInfo(string $method): TestInfo
+    {
+        return new TestInfo(
+            name: $method,
+            caseInfo: new CaseInfo(
+                suiteIdentity: new SuiteIdentity('Output/Unit'),
+                definition: new CaseDefinition(
+                    name: SampleTestClass::class,
+                    type: 'test',
+                    file: Path::create((string) (new \ReflectionClass(SampleTestClass::class))->getFileName()),
+                    reflection: new \ReflectionClass(SampleTestClass::class),
+                ),
+            ),
+            testDefinition: new TestDefinition(new \ReflectionMethod(SampleTestClass::class, $method)),
+        );
+    }
+
+    /**
+     * @param array<non-empty-string, mixed> $document
+     * @return array<non-empty-string, mixed>
+     */
+    private static function firstTest(array $document): array
+    {
+        return $document['suites'][0]['cases'][0]['tests'][0];
+    }
+}

--- a/tests/Output/Unit/Html/HtmlPluginTest.php
+++ b/tests/Output/Unit/Html/HtmlPluginTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Html;
+
+use Internal\Container\ObjectContainer;
+use Internal\Path;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\RunConfiguration;
+use Testo\Application\Internal\EventDispatcher;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\RunResult;
+use Testo\Core\Value\Status;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Event\Framework\SessionStarting;
+use Testo\Output\Html\HtmlPlugin;
+use Testo\Output\Html\Internal\ReportInput;
+use Testo\Test;
+
+/**
+ * How a destination is resolved when both `testo.php` and the command line have something to say.
+ */
+#[Test]
+#[Covers(HtmlPlugin::class)]
+final class HtmlPluginTest
+{
+    public function flagsActivateAnInertReporter(): void
+    {
+        self::inDirectory(static function (string $directory): void {
+            $input = new ReportInput();
+            $input->htmlPath = $directory . '/flag.html';
+            $input->dataPath = $directory . '/flag.json';
+
+            self::run(HtmlPlugin::inert(), $input);
+
+            Assert::true(\is_file($directory . '/flag.html'));
+            Assert::true(\is_file($directory . '/flag.json'));
+        });
+    }
+
+    public function pathsGivenInCodeIgnoreTheFlags(): void
+    {
+        self::inDirectory(static function (string $directory): void {
+            $input = new ReportInput();
+            $input->dataPath = $directory . '/flag.json';
+
+            self::run(new HtmlPlugin($directory . '/configured.html'), $input);
+
+            // The flag left the second slot alone: the inert default in the application plugins is the one
+            // that serves it, and filling it here would write the same file twice and announce it twice.
+            Assert::true(\is_file($directory . '/configured.html'));
+            Assert::false(\is_file($directory . '/flag.json'));
+        });
+    }
+
+    public function anInertReporterWithNoFlagsAttachesNothing(): void
+    {
+        self::inDirectory(static function (string $directory): void {
+            $dispatcher = self::run(HtmlPlugin::inert(), new ReportInput());
+
+            Assert::same(\array_diff((array) \scandir($directory), ['.', '..']), []);
+            // Nothing was attached either — an inert reporter costs a run nothing at all.
+            Assert::same($dispatcher->getListenersForEvent(new SessionStarting())->current(), null);
+        });
+    }
+
+    /**
+     * Configures the reporter against a container holding the given CLI input, then plays the shortest run
+     * there is: a session that starts and finishes with no tests in it.
+     */
+    private static function run(HtmlPlugin $plugin, ReportInput $input): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+
+        $container = new ObjectContainer();
+        $container->set($dispatcher, EventListenerCollector::class);
+        $container->set($dispatcher, EventDispatcherInterface::class);
+        $container->set($input, ReportInput::class);
+        $container->set(new RunConfiguration(), RunConfiguration::class);
+        $container->set(new ApplicationConfig(), ApplicationConfig::class);
+
+        $plugin->configure($container);
+
+        $dispatcher->dispatch(new SessionStarting());
+        $dispatcher->dispatch(new SessionFinished(new RunResult([], Status::Passed)));
+
+        return $dispatcher;
+    }
+
+    /**
+     * @param \Closure(string): void $assertions
+     */
+    private static function inDirectory(\Closure $assertions): void
+    {
+        $directory = \sys_get_temp_dir() . '/testo-html-plugin-' . \bin2hex(\random_bytes(6));
+        \mkdir($directory, 0o777, true);
+
+        try {
+            $assertions($directory);
+        } finally {
+            self::remove(Path::create($directory));
+        }
+    }
+
+    private static function remove(Path $path): void
+    {
+        $target = (string) $path;
+
+        if (\is_dir($target)) {
+            foreach (\array_diff((array) \scandir($target), ['.', '..']) as $entry) {
+                self::remove($path->join((string) $entry));
+            }
+            \rmdir($target);
+            return;
+        }
+
+        \is_file($target) and \unlink($target);
+    }
+}

--- a/tests/Output/Unit/Html/HtmlPluginTest.php
+++ b/tests/Output/Unit/Html/HtmlPluginTest.php
@@ -15,8 +15,10 @@ use Testo\Codecov\Covers;
 use Testo\Common\EventListenerCollector;
 use Testo\Core\Context\RunResult;
 use Testo\Core\Value\Status;
+use Testo\Core\Report\ReportInfo;
 use Testo\Event\Framework\SessionFinished;
 use Testo\Event\Framework\SessionStarting;
+use Testo\Event\Report\ReportFileGenerated;
 use Testo\Output\Html\HtmlPlugin;
 use Testo\Output\Html\Internal\ReportInput;
 use Testo\Test;
@@ -68,6 +70,45 @@ final class HtmlPluginTest
         });
     }
 
+    public function aPathNamedByBothAConfiguredPluginAndAFlagIsWrittenOnce(): void
+    {
+        self::inDirectory(static function (string $directory): void {
+            $input = new ReportInput();
+            $input->htmlPath = $directory . '/report';   // the flag names the configured path
+
+            $generated = self::generatedBy(
+                $input,
+                new HtmlPlugin($directory . '/report'),   // configured
+                HtmlPlugin::inert(),                       // serves the flag
+            );
+
+            // Two instances, one sink: the same destination is deduplicated, so the file is written and
+            // announced once rather than twice with a second, identical IDE button.
+            Assert::count($generated, 1);
+            Assert::same($generated[0]->format, 'html');
+            Assert::true(\is_file($directory . '/report/index.html'));
+        });
+    }
+
+    public function distinctDestinationsAcrossInstancesAreAllServedFromOneRun(): void
+    {
+        self::inDirectory(static function (string $directory): void {
+            $input = new ReportInput();
+            $input->dataPath = $directory . '/flag.json';
+
+            $generated = self::generatedBy(
+                $input,
+                new HtmlPlugin($directory . '/report.html'),   // configured page
+                HtmlPlugin::inert(),                            // flag document
+            );
+
+            // Both land, each announced under its own format — the configured page and the flag's document.
+            Assert::same(\array_map(static fn(ReportInfo $i): string => $i->format, $generated), ['html', 'testo-report']);
+            Assert::true(\is_file($directory . '/report.html'));
+            Assert::true(\is_file($directory . '/flag.json'));
+        });
+    }
+
     /**
      * Configures the reporter against a container holding the given CLI input, then plays the shortest run
      * there is: a session that starts and finishes with no tests in it.
@@ -89,6 +130,42 @@ final class HtmlPluginTest
         $dispatcher->dispatch(new SessionFinished(new RunResult([], Status::Passed)));
 
         return $dispatcher;
+    }
+
+    /**
+     * Configures several plugins against one container — as the application does when the inert default
+     * and a configured instance coexist — plays the shortest run, and returns every report announced as
+     * written, in the order the run stated them.
+     *
+     * @return list<ReportInfo>
+     */
+    private static function generatedBy(ReportInput $input, HtmlPlugin ...$plugins): array
+    {
+        $dispatcher = new EventDispatcher();
+
+        $container = new ObjectContainer();
+        $container->set($dispatcher, EventListenerCollector::class);
+        $container->set($dispatcher, EventDispatcherInterface::class);
+        $container->set($input, ReportInput::class);
+        $container->set(new RunConfiguration(), RunConfiguration::class);
+        $container->set(new ApplicationConfig(), ApplicationConfig::class);
+
+        $generated = [];
+        $dispatcher->addListener(
+            ReportFileGenerated::class,
+            static function (ReportFileGenerated $event) use (&$generated): void {
+                $generated[] = $event->info;
+            },
+        );
+
+        foreach ($plugins as $plugin) {
+            $plugin->configure($container);
+        }
+
+        $dispatcher->dispatch(new SessionStarting());
+        $dispatcher->dispatch(new SessionFinished(new RunResult([], Status::Passed)));
+
+        return $generated;
     }
 
     /**

--- a/tests/Output/suites.php
+++ b/tests/Output/suites.php
@@ -24,6 +24,12 @@ return [
         ),
     ),
     new SuiteConfig(
+        name: 'Output/Feature',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Feature'],
+        ),
+    ),
+    new SuiteConfig(
         name: 'Output/Bench',
         location: new FinderConfig(
             include: [__DIR__ . '/Bench'],

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,10 @@ integrating the Assert module tests into the overall Testo testing process.
 Tests must be isolated from other tests, meaning each module should have
 its own fixtures, mock objects, etc.
 
+Every run writes an HTML report of itself to `runtime/report/index.html` — open it in a browser to inspect
+what ran, with channel output, failures and timings. It is configured in `testo.php` and overwritten by the
+next run.
+
 ## Self Tests
 
 In addition to the commonly known types of tests (unit tests, integration tests, etc.),


### PR DESCRIPTION
## What was changed

<!-- Describe what has changed in this PR -->

Adds a first-class HTML report — a self-contained page rendering a finished run, plus the versioned JSON document behind it, both written from a plugin configured like the other reporters. It opens over `file://` with no server (relative paths, a classic-script bundle, data as a global-assigning script) and reaches no network at all. The output path picks the layout: a `.html` destination inlines everything into one file, anything else fills a directory with `index.html` and its assets. An inert copy joins the application defaults, so `--log-html` works without any `testo.php` change; `--log-report` (the standalone document on its own, for CI and external tooling) is wired but left commented until wanted.

The report represents what Testo can express — every status kept distinguishable, per-test channel output with level filtering, assertions and failures with diffs and traces, data providers, retries as attempts, benches, structure, timings and the environment — across tabbed views (overview, tests, channels, timeline, benches) with search, filters reflected in the URL, deep links per test, and light/dark themes. The run's phases are shown startup/discovery/tests/teardown, with the tests phase split into execution (the union of the test intervals, overlaps counted once), the pipeline overhead around them, and the concurrency boost. The document is deterministic so it diffs and golden-tests, and a `RunConfiguration` primitive carries a run's effective input for the report to describe it, with the environment deliberately left out so a committed report never travels with a token.

See commit history for details.

## Why?

<!-- Tell your future self why have you made these changes -->

Testo's defining features — channels, every status, data providers, retries, benches — have no home in a generic test-list page. A browsable, diffable report produced on every run, alongside the terminal/JUnit/JSON outputs, exposes all of them, and the IDE plugin turns its announced location into a button. Keeping the JSON document a first-class artifact lets CI and external tooling consume a whole run without parsing HTML, and the phase/overhead/boost breakdown answers where a run actually spent its time — which summed test time alone cannot, once tests overlap.

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [x] Documentation
