### PR TITLE
feat: allow #[RunInFiber] and #[RunInRevolt] on free functions

### DIFF
--- a/bridge/revolt/src/RunInRevolt.php
+++ b/bridge/revolt/src/RunInRevolt.php
@@ -39,6 +39,6 @@ use Testo\Pipeline\Attribute\Interceptable;
  *
  * @api
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 #[FallbackInterceptor(RunInRevoltInterceptor::class)]
 final readonly class RunInRevolt implements Interceptable {}

--- a/bridge/revolt/tests/Self/functions.php
+++ b/bridge/revolt/tests/Self/functions.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Revolt\Self;
+
+use Revolt\EventLoop;
+use Testo\Assert;
+use Testo\Bridge\Revolt\Internal\RunInRevoltInterceptor;
+use Testo\Bridge\Revolt\RunInRevolt;
+use Testo\Codecov\Covers;
+use Testo\Filter\Group;
+use Testo\Test;
+
+/**
+ * The suspend/resume round-trip only completes because the free function itself runs on the Revolt
+ * loop — a bare fiber with no loop would leave the timer's resume unfired.
+ */
+#[Test]
+#[RunInRevolt]
+#[Group('async')]
+#[Covers(RunInRevolt::class)]
+#[Covers(RunInRevoltInterceptor::class)]
+function functionLevelRunsOnTheLoop(): void
+{
+    Assert::notNull(\Fiber::getCurrent());
+
+    $suspension = EventLoop::getSuspension();
+    EventLoop::delay(0.001, static fn() => $suspension->resume('resumed'));
+
+    Assert::same($suspension->suspend(), 'resumed');
+}

--- a/plugin/fiber/src/RunInFiber.php
+++ b/plugin/fiber/src/RunInFiber.php
@@ -45,7 +45,7 @@ use Testo\Pipeline\Attribute\Interceptable;
  *
  * @api
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 #[FallbackInterceptor(RunInFiberInterceptor::class)]
 #[FallbackInterceptor(CoroutineScopeInterceptor::class)]
 final readonly class RunInFiber implements Interceptable

--- a/plugin/fiber/tests/Self/functions.php
+++ b/plugin/fiber/tests/Self/functions.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fiber\Self;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Fiber\Coroutine;
+use Testo\Fiber\Internal\CoroutineScopeInterceptor;
+use Testo\Fiber\Internal\RunInFiberInterceptor;
+use Testo\Fiber\RunInFiber;
+use Testo\Filter\Group;
+use Testo\Test;
+
+/**
+ * `spawn()` only schedules the coroutine — it takes its first step once the body yields at `await()`,
+ * so the recorded order is body-first, and observing it at all proves the scheduler drives a fiber
+ * opened for a free function.
+ */
+#[Test]
+#[RunInFiber]
+#[Group('async')]
+#[Covers(RunInFiber::class)]
+#[Covers(RunInFiberInterceptor::class)]
+#[Covers(CoroutineScopeInterceptor::class)]
+function functionLevelRunsInAFiber(): void
+{
+    Assert::notNull(\Fiber::getCurrent());
+
+    $log = [];
+
+    $task = Coroutine::spawn(static function () use (&$log): int {
+        $log[] = 'coroutine:start';
+        \Fiber::suspend();
+        $log[] = 'coroutine:resumed';
+
+        return 42;
+    });
+
+    $log[] = 'body';
+
+    Assert::same($task->await(), 42);
+    Assert::same($log, ['body', 'coroutine:start', 'coroutine:resumed']);
+}


### PR DESCRIPTION
## 🔍 What was changed

- `#[RunInFiber]` and `#[RunInRevolt]` now declare `Attribute::TARGET_FUNCTION`, so a `#[Test]` free function can carry them — previously they were class/method only.
- Added function-level self-tests for both, mirroring the existing method/class-level ones: the body runs inside a fiber, and a spawned coroutine (`Coroutine::spawn`/`await`) resp. an awaited Revolt timer resumes to completion.

## Why?

The attributes already worked on class methods; nothing stopped the same behaviour on plain test functions except the missing attribute target. The self-tests pin that a function-level test really opens the fiber/loop scope, not just that the attribute is accepted.

## Checklist

- How was this tested:
  - [x] Unit tests added
