### PR TITLE
docs(skills): add testo-run-tests — running the suite from the CLI

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,7 @@ that an AI coding agent can load on demand.
 
 | Skill | Use when… |
 |---|---|
+| [`testo-run-tests`](testo-run-tests/SKILL.md) | Running the suite or a subset from the CLI — the `--json` report, filters (`--suite`/`--filter`/`--path`/`--group`/`--type`), exit semantics. |
 | [`testo-write-tests`](testo-write-tests/SKILL.md) | Writing or modifying a normal test class — covers `#[Test]`, `Assert`, `Expect`, lifecycle hooks. |
 | [`testo-data-driven`](testo-data-driven/SKILL.md) | Parameterizing a test — `#[DataSet]`, `#[DataProvider]`, `#[DataZip]`, `#[DataCross]`. |
 | [`testo-flaky-tests`](testo-flaky-tests/SKILL.md) | Stabilizing flaky tests with `#[Retry]` or stress-testing with `#[Repeat]`. |

--- a/skills/testo-benchmarks/SKILL.md
+++ b/skills/testo-benchmarks/SKILL.md
@@ -62,7 +62,7 @@ vendor/bin/testo --type=!bench   # everything except benches
 vendor/bin/testo --type=bench    # only benches
 ```
 
-`--type` is repeatable and `!`-prefixed values exclude (exclusion wins). Putting benches in their own `SuiteConfig` (with `BenchmarkPlugin`, enabled per suite) and running `--suite=Bench` works too.
+Filter semantics live in the `testo-run-tests` skill. Putting benches in their own `SuiteConfig` (with `BenchmarkPlugin`, enabled per suite) and running `--suite=Bench` works too.
 
 ## Writing a clean benchmark
 

--- a/skills/testo-configure/SKILL.md
+++ b/skills/testo-configure/SKILL.md
@@ -177,31 +177,13 @@ Keep it readable — if the logic gets long, extract a helper, don't pile up ter
 ## CLI cheat-sheet
 
 ```
-vendor/bin/testo init                  # bootstrap testo.php + composer scripts
-vendor/bin/testo init --path=app       # bootstrap inside a subdirectory
-vendor/bin/testo                       # all suites
-vendor/bin/testo --suite=Unit          # one suite
-vendor/bin/testo --suite=Unit --suite=Integration  # multiple
-vendor/bin/testo --path=tests/Unit/Foo # subdirectory of a suite
-vendor/bin/testo --filter='UserService'  # by name
-vendor/bin/testo --group=integration   # only the #[Group('integration')] tests
-vendor/bin/testo --group=!slow         # everything except the "slow" group
-vendor/bin/testo --type=test           # only #[Test], not benches/inline (OR across values)
-vendor/bin/testo --type=!bench         # everything except benches; prefix with `!` to exclude
-vendor/bin/testo --coverage            # force coverage on
-vendor/bin/testo --no-coverage         # force coverage off
-vendor/bin/testo --coverage-level=branch   # line|branch|path; overrides the level set in testo.php
-vendor/bin/testo --coverage-clover=build/clover.xml        # write Clover report (no testo.php needed)
-vendor/bin/testo --coverage-cobertura=build/cobertura.xml  # write Cobertura report
-vendor/bin/testo --coverage-xml=build/coverage-xml         # write coverage XML dir (Infection)
-vendor/bin/testo --teamcity            # TeamCity output (CI/IDE)
-vendor/bin/testo --json                # minimal JSON on stdout: run summary + failed tests (for LLM agents / CI scripts)
-vendor/bin/testo --log-json=build/report.json  # same JSON to a file, keeps the terminal output (like --log-junit)
-vendor/bin/testo --log-html=runtime/report        # self-contained HTML report: directory with index.html + assets
-vendor/bin/testo --log-html=build/report.html     # ...or a single inlined file, chosen by the .html extension
-vendor/bin/testo --log-report=build/report.json   # the full run as a versioned JSON document (data behind the HTML)
-vendor/bin/testo --config=path/to/testo.php
+vendor/bin/testo init                          # bootstrap testo.php + composer scripts
+vendor/bin/testo init --path=app               # bootstrap inside a subdirectory
+vendor/bin/testo --config=path/to/testo.php    # run with a config outside the project root
 ```
+
+Running and filtering (`--json`, `--suite`, `--filter`, `--path`, `--group`, `--type`, report
+outputs) are covered by the `testo-run-tests` skill; coverage flags by the `testo-coverage` skill.
 
 ## Pitfalls
 
@@ -211,4 +193,4 @@ vendor/bin/testo --config=path/to/testo.php
 - **Don't shell out to `composer dump-autoload` from `testo.php`.** Composer's autoloader is already booted by the CLI entry. Avoid side-effects in config.
 - **Don't read environment variables without a fallback.** `\getenv('FOO') ?: 'default'` — CI dropouts otherwise silently change which suites run.
 - **`testo.php` is required.** If a project doesn't have one, run `vendor/bin/testo init` (see *Bootstrap with `init`*) or, for full control, write the minimal version above by hand.
-- **An empty run is not a success.** When no tests are discovered — nothing matched, or a filter (`--filter`/`--path`/`--suite`/`--type`/`--group`) excluded everything — the run is marked **risky** and exits **non-zero** (so CI fails instead of going green on a test-free build). The terminal shows a `NO TESTS` banner, `--json` reports `"status": "risky"` with `"total": 0`, and `--teamcity` emits a `buildProblem`. An over-narrow filter is the usual cause.
+- **An empty run is not a success.** Zero discovered tests → status **risky**, non-zero exit (details in the `testo-run-tests` skill). On the config side the usual causes are a suite `location` pointing at the wrong directory or an empty suite.

--- a/skills/testo-run-tests/SKILL.md
+++ b/skills/testo-run-tests/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: testo-run-tests
+description: Run tests with the Testo CLI and act on the result. Use when executing a project's test suite or a subset (one test, one file, one suite, a group), when verifying a change didn't break tests, or when parsing a Testo run report. Triggers: "run the tests", "does it pass", "run only X", "re-run the failing test".
+---
+
+# Running Testo tests
+
+Always run through the Testo CLI, and always with `--json`:
+
+```
+vendor/bin/testo --json
+```
+
+`--json` replaces the human progress stream with one compact JSON object on stdout: a run
+summary plus the failed tests only. Passing, skipped, and risky tests collapse into counts, so
+even a large suite costs almost no context. The human-readable terminal output is not a stable
+interface — parse the JSON. When a human also needs terminal output (CI logs), use
+`--log-json=build/report.json` instead: same JSON to a file, terminal output kept.
+
+## Reading the report
+
+```json
+{
+    "status": "failed",
+    "duration": 1.42,
+    "totals": {"total": 120, "passed": 118, "failed": 1, "error": 1},
+    "failures": [
+        {
+            "test": "App\\Tests\\UserServiceTest::createsUser",
+            "status": "failed",
+            "exception": "Testo\\Assert\\AssertionFailedError",
+            "message": "...",
+            "file": "/app/tests/UserServiceTest.php",
+            "line": 42,
+            "trace": ["#0 /app/tests/UserServiceTest.php:42: ..."],
+            "causedBy": [{"exception": "...", "message": "...", "file": "...", "line": 1}],
+            "output": [{"channel": "stdout", "content": "..."}]
+        }
+    ]
+}
+```
+
+- `status` — the run verdict. **Gate on `"status": "passed"`**, not on `failures` being empty:
+  a run can be risky with zero failures.
+- `totals` — counts keyed by lowercased test status (`passed`, `failed`, `error`, `skipped`,
+  `risky`, `flaky`, `cancelled`, `aborted`); zero counts are omitted.
+- `failures` — every failed/errored test with what you need to fix it: the throwable, its
+  `previous` chain (`causedBy`), a stack trace trimmed at the test boundary, and captured
+  output (`stdout`, log channels).
+
+## Selecting what to run
+
+Every filter is repeatable; different filters combine, each narrowing further:
+
+```
+vendor/bin/testo --json --suite=Unit                              # one suite (name from testo.php)
+vendor/bin/testo --json --filter=UserServiceTest                  # by name fragment
+vendor/bin/testo --json --filter='UserServiceTest::createsUser'   # one test method
+vendor/bin/testo --json --path=tests/Unit/UserServiceTest.php     # one file
+vendor/bin/testo --json --path='tests/Unit/User*'                 # glob: *, ?, [abc]
+vendor/bin/testo --json --group=db --group=!slow                  # groups: OR to include, ! to exclude
+vendor/bin/testo --json --type=!bench                             # types: test, inline, bench, profile
+```
+
+- `--filter` accepts `Class::method`, a FQN (class or function), or a bare fragment
+  (method name, function name, or short class name).
+- `--group` matches `#[Group('name')]`; `--type` matches how the test is declared —
+  `test` (`#[Test]`), `inline` (`#[TestInline]`), `bench`, `profile`. For both, values
+  OR together and a `!`-prefixed value excludes; exclusion wins over inclusion.
+- If the project has `#[Bench]` benchmarks, they are slow — add `--type=!bench` unless the
+  task is benchmarking (see the `testo-benchmarks` skill).
+
+## Exit code and the empty run
+
+The exit code is 0 only for a passed run. A run that discovers **zero tests** is not green:
+it reports `"status": "risky"` with `"total": 0` and exits non-zero. The usual cause is an
+over-narrow filter — widen it (a typo in `--filter`, a `--path` that matches nothing, a
+`--suite` name that doesn't exist in `testo.php`).
+
+## Beyond a plain run
+
+- Coverage (`--coverage`, `--coverage-clover=`, `--coverage-level=`, …) — see the
+  `testo-coverage` skill.
+- `--log-junit=`, `--log-html=` (a `.html` path → single file, anything else → directory),
+  `--log-report=` (the full run as a versioned JSON document — the data behind the HTML),
+  `--teamcity` — reports for CI and IDEs, not for agent parsing.
+- `--config=path/to/testo.php` when the config is not at the project root.
+- Full flag list: `vendor/bin/testo --help`.

--- a/skills/testo-write-tests/SKILL.md
+++ b/skills/testo-write-tests/SKILL.md
@@ -223,25 +223,19 @@ final class MysqlConnectionTest
 ```
 
 A test's group set is the union of all groups reachable from it: its own method (and any overridden
-parent method), the test class, its parent classes, and traits. Select with `--group` (OR across
-values); prefix with `!` to exclude. Group filters AND with name/path/suite filters.
+parent method), the test class, its parent classes, and traits. Groups are selected at run time with
+`--group` — see the `testo-run-tests` skill.
 
 ## Running
 
+Run the test you just wrote through the Testo CLI, always with `--json`:
+
 ```
-vendor/bin/testo --json                                # all suites
-vendor/bin/testo --json --suite=Unit                   # one suite
-vendor/bin/testo --json --filter='UserServiceTest'     # by name
-vendor/bin/testo --json --path=tests/Unit/UserService  # by path
-vendor/bin/testo --json --group=integration            # only the "integration" group
-vendor/bin/testo --json --group=!slow                  # everything except the "slow" group
+vendor/bin/testo --json --filter='UserServiceTest'
 ```
 
-Always pass `--json` (as above) for a compact, machine-readable report that's cheap to parse — a run
-summary plus the failed tests. Use `--log-json=build/report.json` to write it to a file while keeping
-the terminal output.
-
-Always run tests through the Testo CLI (`vendor/bin/testo`).
+Filter selection (`--suite`/`--filter`/`--path`/`--group`/`--type`), the JSON report shape, and exit
+semantics are covered by the `testo-run-tests` skill — escalate there before adding other flags.
 
 ## Pitfalls
 


### PR DESCRIPTION
## 🔍 What was changed

- New `testo-run-tests` skill — the single source of truth for running tests from the CLI: the mandatory `--json` report (its shape and gating on `"status": "passed"`), the `--suite`/`--filter`/`--path`/`--group`/`--type` filters, and the empty-run → risky / non-zero-exit semantics. Registered in `skills/README.md`.
- `testo-write-tests`, `testo-configure` and `testo-benchmarks` keep only their own branches (one typical run command, `init`/`--config`, bench type filtering) and point at the new skill instead of restating the run rules.

## Why?

Run guidance was duplicated across three skills and drifted independently. Agents also need the `--json` rule stated once and firmly, so a test run doesn't flood their context with the human progress stream.

## Checklist

- How was this tested:
  - [x] Every claim verified against the live CLI: `run --help`, empty run → `"status": "risky"` with exit 1, `--filter='SummaryTest::emptyByDefault'` and the FQN form → green JSON with exit 0
