### PR TITLE
feat(bridge-double): add Double test-double bridge

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -65,9 +65,8 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      # Infection and the bridge runtime deps are isolated via bamarni/composer-bin-plugin, not in
-      # the root install. `bin all` installs every namespace; --ignore-platform-req=php lets a
-      # higher-floor bridge (double) install here too — it only loads where its suite gates in.
+      # Infection and the bridge runtime deps are isolated via bamarni-bin, not in the root install.
+      # --ignore-platform-req=php lets a higher-floor bridge (double) install here too.
       - name: Install bin tools
         run: composer bin all install --ignore-platform-req=php
 
@@ -110,8 +109,8 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      # PHPUnit, Infection, rector (for the build) and the bridge runtime deps (for the mirror's
-      # bridge tests) are all isolated via bamarni/composer-bin-plugin, not in the root install.
+      # PHPUnit, Infection, rector and the bridge runtime deps are isolated via bamarni-bin, not in
+      # the root install.
       - name: Install bin tools
         run: composer bin all install --ignore-platform-req=php
 

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -65,9 +65,11 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      # Infection is isolated via bamarni/composer-bin-plugin and not installed by the root install.
-      - name: Install isolated Infection
-        run: composer bin infection install
+      # Infection and the bridge runtime deps are isolated via bamarni/composer-bin-plugin, not in
+      # the root install. `bin all` installs every namespace; --ignore-platform-req=php lets a
+      # higher-floor bridge (double) install here too — it only loads where its suite gates in.
+      - name: Install bin tools
+        run: composer bin all install --ignore-platform-req=php
 
       - name: Run Infection
         run: composer infect:ci
@@ -108,12 +110,10 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      # PHPUnit and Infection are isolated via bamarni/composer-bin-plugin, not in the root install.
-      - name: Install isolated PHPUnit
-        run: composer bin phpunit install
-
-      - name: Install isolated Infection
-        run: composer bin infection install
+      # PHPUnit, Infection, rector (for the build) and the bridge runtime deps (for the mirror's
+      # bridge tests) are all isolated via bamarni/composer-bin-plugin, not in the root install.
+      - name: Install bin tools
+        run: composer bin all install --ignore-platform-req=php
 
       # Copy the Testo suite, convert it to PHPUnit (Rector) and relocate it to tests/PhpUnit.
       - name: Build the PHPUnit mirror

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -46,5 +46,9 @@ jobs:
         with:
           dependency-versions: highest
 
+      # rector is isolated in tools/rector; bin-links put its binary on vendor/bin.
+      - name: Install bin tools
+        run: composer bin all install --ignore-platform-req=php
+
       - name: Run Rector
         run: composer rector:ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
+      # Bin tools carry deps with a higher PHP floor than the matrix (e.g. tools/double).
+      # They install everywhere but only load where the platform allows, so ignore the check.
+      - name: Install bin tools
+        run: composer bin all install --ignore-platform-req=php
+
       - name: Run Tests
         run: composer test:ci
 
@@ -84,6 +89,9 @@ jobs:
         uses: ramsey/composer-install@v3
         with:
           dependency-versions: highest
+
+      - name: Install bin tools
+        run: composer bin all install --ignore-platform-req=php
 
       - name: Run Tests with Coverage
         run: composer test:cc

--- a/bridge/double/.github/workflows/close-prs.yml
+++ b/bridge/double/.github/workflows/close-prs.yml
@@ -1,0 +1,14 @@
+name: Close PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    uses: php-testo/gh-actions/.github/workflows/close-foreign-prs.yml@v1
+    with:
+      upstream-url: https://github.com/php-testo/testo

--- a/bridge/double/CHANGELOG.md
+++ b/bridge/double/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## Changelog

--- a/bridge/double/README.md
+++ b/bridge/double/README.md
@@ -1,0 +1,62 @@
+<p align="center">
+    <a href="https://github.com/php-testo/testo"><img alt="TESTO"
+         src="https://github.com/php-testo/.github/blob/1.x/resources/logo-full.svg?raw=true"
+         style="width: 2in; display: block"
+    /></a>
+</p>
+
+<p align="center">Double bridge</p>
+
+<div align="center">
+
+[![Documentation](https://img.shields.io/badge/Documentation-blue?style=for-the-badge&logo=gitbook&logoColor=white)](https://php-testo.github.io)
+[![Support on Boosty](https://img.shields.io/static/v1?style=for-the-badge&label=&message=Sponsorship&logo=Boosty&logoColor=white&color=%23F15F2C)](https://boosty.to/roxblnfk)
+
+</div>
+
+<br />
+
+> [!IMPORTANT]
+> ## 🪞 This is a read-only mirror.
+>
+> Active development of the Testo project lives in [**php-testo/testo**](https://github.com/php-testo/testo) under `bridge/double/`. This repository is **automatically synchronized** from there on every release.
+>
+> File issues and pull requests in the [main monorepo](https://github.com/php-testo/testo/issues), not here.
+
+## About
+
+[Double](https://github.com/jasonmccreary/double) is a modern PHP test-double library — one unified `Double` type covers mocks, stubs and spies. This bridge wires its verification into Testo: register `DoublePlugin` and `Double::verifyAll()` is called after every test, so `expects()` and `received()` assertions are always verified and the pending doubles are cleared between tests — no per-test `verify()` boilerplate.
+
+```php
+// testo.php
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\SuiteConfig;
+use Testo\Bridge\Double\DoublePlugin;
+
+return new ApplicationConfig(
+    plugins: [new DoublePlugin()],
+    suites:  [new SuiteConfig(name: 'Unit', location: ['tests/Unit'])],
+);
+```
+
+```php
+use JMac\Testing\Double;
+
+$repository = Double::for(BookRepository::class);
+$repository->expects('find')->with(123)->returns($book);
+
+$service = new CatalogService($repository);
+$service->lookup(123);
+// The plugin verifies `find` was called as expected once the test returns.
+```
+
+## Install
+
+```bash
+composer require --dev testo/bridge-double
+```
+
+[![PHP](https://img.shields.io/packagist/php-v/testo/bridge-double.svg?style=flat-square&logo=php)](https://packagist.org/packages/testo/bridge-double)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/testo/bridge-double.svg?style=flat-square&logo=packagist)](https://packagist.org/packages/testo/bridge-double)
+[![License](https://img.shields.io/packagist/l/testo/bridge-double.svg?style=flat-square)](https://github.com/php-testo/testo/blob/1.x/LICENSE.md)
+[![Total Downloads](https://img.shields.io/packagist/dt/testo/bridge-double.svg?style=flat-square)](https://packagist.org/packages/testo/bridge-double/stats)

--- a/bridge/double/composer.json
+++ b/bridge/double/composer.json
@@ -1,0 +1,55 @@
+{
+    "name": "testo/bridge-double",
+    "description": "Double bridge for the Testo testing framework.",
+    "license": "BSD-3-Clause",
+    "type": "library",
+    "keywords": [
+        "testo",
+        "double",
+        "mock",
+        "stub",
+        "spy",
+        "testing"
+    ],
+    "authors": [
+        {
+            "name": "Aleksei Gagarin (roxblnfk)",
+            "homepage": "https://github.com/roxblnfk"
+        }
+    ],
+    "funding": [
+        {
+            "type": "boosty",
+            "url": "https://boosty.to/roxblnfk"
+        }
+    ],
+    "require": {
+        "php": ">=8.3",
+        "jasonmccreary/double": "^0.6.1",
+        "testo/testo": "0.10.39 - 1"
+    },
+    "require-dev": {
+        "testo/assert": "^0.1.13",
+        "testo/bridge-revolt": "^0.1.1",
+        "testo/codecov": "^0.1.12",
+        "testo/fiber": "^0.1.2",
+        "testo/test": "^0.1.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "Testo\\Bridge\\Double\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Bridge\\Double\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.x-dev"
+        }
+    }
+}

--- a/bridge/double/composer.json
+++ b/bridge/double/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "jasonmccreary/double": "^0.6.1",
+        "jasonmccreary/double": "dev-master",
         "testo/testo": "0.10.39 - 1"
     },
     "require-dev": {

--- a/bridge/double/composer.json
+++ b/bridge/double/composer.json
@@ -13,7 +13,7 @@
     ],
     "authors": [
         {
-            "name": "Aleksei Gagarin (roxblnfk)",
+            "name": "Aleksei Gagarin",
             "homepage": "https://github.com/roxblnfk"
         }
     ],
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "jasonmccreary/double": "dev-master",
+        "jasonmccreary/double": "^0.7",
         "testo/testo": "0.10.39 - 1"
     },
     "require-dev": {

--- a/bridge/double/src/DoublePlugin.php
+++ b/bridge/double/src/DoublePlugin.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Bridge\Double;
+
+use Internal\Container\Container;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Common\PluginConfigurator;
+use Testo\Pipeline\InterceptorCollector;
+
+/**
+ * Plugin that automatically verifies every {@see \JMac\Testing\Double} created during a test.
+ *
+ * Register it in your {@see \Testo\Application\ApplicationConfig} `$plugins` list:
+ *
+ * ```php
+ * // testo.php
+ * return new ApplicationConfig(
+ *     plugins: [new DoublePlugin()],
+ *     suites:  [new SuiteConfig(name: 'Unit', location: ['tests/Unit'])],
+ * );
+ * ```
+ *
+ * Once registered, `Double::verifyAll()` runs after every test, so unmet `expects()` and
+ * `received()` assertions fail the test with no per-test `verify()` teardown boilerplate.
+ *
+ * @api
+ */
+final readonly class DoublePlugin implements PluginConfigurator
+{
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $container->get(InterceptorCollector::class)->addInterceptor(new DoubleInterceptor());
+    }
+}

--- a/bridge/double/src/Internal/DoubleInterceptor.php
+++ b/bridge/double/src/Internal/DoubleInterceptor.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Bridge\Double\Internal;
+
+use JMac\Testing\Double;
+use Testo\Assert\Internal\StaticState;
+use Testo\Assert\State\Expectation\ExpectationFailed;
+use Testo\Assert\State\Expectation\ExpectationFulfilled;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
+use Testo\Core\Value\TestType;
+use Testo\Pipeline\Attribute\InterceptorOptions;
+use Testo\Pipeline\Middleware\TestRunInterceptor;
+
+/**
+ * Arms {@see Double::armAutoVerify()} before every test and runs {@see Double::verifyAll()} afterwards
+ * in a `finally` block: unmet `expects()` and deferred `received()` assertions fail the test. `verifyAll()`
+ * returns how many checks it performed, which the bridge reports to the Assert plugin so a double-only test
+ * still counts as making assertions. It always drains Double's global state, so an unmet expectation fails
+ * an otherwise-passing test while an already-failed result is left alone.
+ *
+ * Runs innermost so the teardown fires as close as possible to the test function.
+ *
+ * @internal
+ * @psalm-internal Testo\Bridge\Double
+ */
+#[InterceptorOptions(
+    order: InterceptorOptions::ORDER_CLOSE_TO_TEST,
+    testType: TestType::Test,
+)]
+final readonly class DoubleInterceptor implements TestRunInterceptor
+{
+    #[\Override]
+    public function runTest(TestInfo $info, callable $next): TestResult
+    {
+        # Arm before the test body runs so every double it creates is collected for verification.
+        Double::armAutoVerify();
+
+        $result = null;
+        try {
+            $result = $this->run($info, $next);
+        } finally {
+            try {
+                $verified = Double::verifyAll();
+                $verified > 0 and self::reportVerifiedChecks($verified);
+            } catch (\Throwable $e) {
+                # Record the unmet expectation on the test, then turn it into a normal failure — an
+                # exception escaping here would abort the pipeline (Status::Aborted) instead. Leave an
+                # already-failed result alone; a null $result means $next() threw — let it propagate.
+                $failure = self::reportFailedCheck($e);
+                $result?->status === Status::Passed and $result = $result
+                    ->with(status: Status::Failed)
+                    ->withFailure($failure ?? $e);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Record the `$count` passed Double checks as one fulfilled assertion on the current test, so a test
+     * whose only checks are `expects()` / `received()` verifications is not flagged as making no assertions.
+     *
+     * No-op without the Assert plugin (the {@see \class_exists()} guard). Runs innermost, before the
+     * Assert plugin reads the history, so the record lands on the current test.
+     */
+    private static function reportVerifiedChecks(int $count): void
+    {
+        if (!\class_exists(StaticState::class)) {
+            return;
+        }
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = new ExpectationFulfilled(
+            \sprintf('%d Double %s verified', $count, $count === 1 ? 'check was' : 'checks were'),
+            '',
+        );
+    }
+
+    /**
+     * Record an unmet Double expectation as a failed assertion on the current test and return it,
+     * so the caller can use the same record as the test's failure.
+     *
+     * Returns null without the Assert plugin — the caller then falls back to the raw Double exception.
+     */
+    private static function reportFailedCheck(\Throwable $e): ?ExpectationFailed
+    {
+        if (!\class_exists(StaticState::class)) {
+            return null;
+        }
+
+        $failure = new ExpectationFailed(
+            expectation: 'the Double expectations are fulfilled',
+            context: '',
+            reason: $e->getMessage(),
+            details: '',
+        );
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = $failure;
+
+        return $failure;
+    }
+
+    /**
+     * Run the test, keeping this test's pending doubles bound to it across fiber suspensions.
+     *
+     * Double's pending doubles live in process-global state, so under concurrent (fiber-based) execution
+     * sibling tests would sweep each other's doubles into the wrong teardown. On every suspension we park
+     * this test's state with {@see Double::captureAutoVerifyScope()} and hand a fresh slate to the sibling;
+     * on resumption we reinstall it with {@see Double::restoreAutoVerifyScope()}.
+     *
+     * @param callable(TestInfo): TestResult $next
+     */
+    private function run(TestInfo $info, callable $next): TestResult
+    {
+        if (\Fiber::getCurrent() === null) {
+            return $next($info);
+        }
+
+        $fiber = new \Fiber(static fn(): TestResult => $next($info));
+        $value = $fiber->start();
+        while (!$fiber->isTerminated()) {
+            $scope = Double::captureAutoVerifyScope();
+            try {
+                $resume = \Fiber::suspend($value);
+            } catch (\Throwable $e) {
+                Double::restoreAutoVerifyScope($scope);
+                $value = $fiber->throw($e);
+                continue;
+            }
+
+            Double::restoreAutoVerifyScope($scope);
+            $value = $fiber->resume($resume);
+        }
+
+        /** @var TestResult $result */
+        $result = $fiber->getReturn();
+        return $result;
+    }
+}

--- a/bridge/double/src/Internal/DoubleInterceptor.php
+++ b/bridge/double/src/Internal/DoubleInterceptor.php
@@ -4,16 +4,9 @@ declare(strict_types=1);
 
 namespace Testo\Bridge\Double\Internal;
 
-use JMac\Testing\AutoVerifyScope;
+use JMac\Testing\AutoVerifySnapshot;
+use JMac\Testing\CheckEvent;
 use JMac\Testing\Double;
-use JMac\Testing\Engine\DoubleState;
-use JMac\Testing\Exceptions\ExpectationCallLimitExceededException;
-use JMac\Testing\Exceptions\ExpectationCallMismatchException;
-use JMac\Testing\Exceptions\OutOfOrderCallException;
-use JMac\Testing\Exceptions\UnexpectedCallException;
-use JMac\Testing\Exceptions\UnsatisfiedExpectationException;
-use JMac\Testing\Exceptions\UnsatisfiedReceivedAssertionException;
-use JMac\Testing\Exceptions\UnusedAssertionException;
 use Testo\Assert\Internal\StaticState;
 use Testo\Assert\State\Expectation\ExpectationFailed;
 use Testo\Assert\State\Expectation\ExpectationFulfilled;
@@ -25,18 +18,17 @@ use Testo\Pipeline\Attribute\InterceptorOptions;
 use Testo\Pipeline\Middleware\TestRunInterceptor;
 
 /**
- * Arms {@see Double::armAutoVerify()} before every test and runs {@see Double::verifyAll()} afterwards
- * in a `finally` block: unmet `expects()` and deferred `received()` assertions fail the test. Before
- * verifying, the bridge snapshots the pending doubles and reports one fulfilled assertion per double
- * (with its recorded calls) to the Assert plugin, so a double-only test still counts as making assertions
- * and its report carries what was checked. It always drains Double's global state, so an unmet expectation
- * fails an otherwise-passing test while an already-failed result is left alone.
+ * Bridges Double's auto-verification into a Testo test.
  *
- * A Double check that throws inside the test body (a failed `received()`, `unused()` or an unexpected
- * call on a strict double) is captured by the runner into the result's failure. The bridge records it in
- * the assertion history so the double's diagnostic stays visible, then passes the result through untouched:
- * whether the test ends up failed or passes because `#[ExpectException]` caught that throw is decided by
- * the rest of the pipeline, not here.
+ * Turns on {@see Double::enableAutoVerify()} before the test body and runs {@see Double::verifyAll()}
+ * afterwards in a `finally`: unmet `expects()` and deferred `received()` assertions are checked there, and
+ * a failure turns an otherwise-passing test into a failed one (an already-failed result is left alone).
+ *
+ * A {@see Double::listen()} listener mirrors every check into the Assert plugin's history the moment it
+ * resolves, pass or fail, immediate call-time failures included. So a double-only test still counts as
+ * making assertions, and the report shows what was checked in the order it happened. The listener only
+ * records; it never changes the result, so whether a body-thrown check failure fails the test or is
+ * absorbed by `#[ExpectException]` stays the rest of the pipeline's call.
  *
  * Runs innermost so the teardown fires as close as possible to the test function.
  *
@@ -52,184 +44,69 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
     #[\Override]
     public function runTest(TestInfo $info, callable $next): TestResult
     {
-        # Arm before the test body runs so every double it creates is collected for verification.
-        Double::armAutoVerify();
+        self::ensureListening();
+
+        # Enable before the test body runs so every double it creates is collected for verification.
+        Double::enableAutoVerify();
 
         $result = null;
         try {
             $result = $this->run($info, $next);
         } finally {
             try {
-                # Snapshot the pending doubles before verifying so we can describe each in the test's
-                # assertion history; restore it verbatim so verifyAll() checks exactly the same set.
-                $scope = Double::captureAutoVerifyScope();
-                $records = \class_exists(StaticState::class) ? self::describeVerified($scope) : [];
-                Double::restoreAutoVerifyScope($scope);
                 Double::verifyAll();
-                $records === [] or self::pushHistory($records);
             } catch (\Throwable $e) {
-                # Record the unmet expectation on the test, then turn it into a normal failure — an
-                # exception escaping here would abort the pipeline (Status::Aborted) instead. Leave an
-                # already-failed result alone; a null $result means $next() threw — let it propagate.
-                $failure = self::reportFailedCheck($e);
+                # The unmet expectation was already recorded by the listener. Turn it into a normal failure
+                # here — an exception escaping would abort the pipeline (Status::Aborted) instead. Leave an
+                # already-failed result alone; a null $result means $next() threw, let it propagate.
                 $result?->status === Status::Passed and $result = $result
                     ->with(status: Status::Failed)
-                    ->withFailure($failure ?? $e);
+                    ->withFailure($e);
             }
         }
-
-        # A Double check that failed in the test body arrives as the result's failure. Record it, leaving
-        # the result itself untouched so the pipeline still decides the final status (including a pass when
-        # #[ExpectException] catches that throw).
-        $result === null or self::reportBodyFailure($result);
 
         return $result;
     }
 
     /**
-     * Every Double exception that represents a *check* failing, as opposed to a misuse error (calling an
-     * unknown or static method, misconfiguring a mode). Only these are recorded as a failed check.
+     * Register the check recorder with Double once per process. Double's listener registry is process-wide
+     * and long-lived by design, so registering per test would pile up duplicates. No-op without the Assert
+     * plugin: there is no history to write to, and {@see Double::verifyAll()} still fails tests on its own.
      */
-    private const CHECK_FAILURES = [
-        UnsatisfiedExpectationException::class,
-        UnsatisfiedReceivedAssertionException::class,
-        UnusedAssertionException::class,
-        UnexpectedCallException::class,
-        ExpectationCallLimitExceededException::class,
-        ExpectationCallMismatchException::class,
-        OutOfOrderCallException::class,
-    ];
-
-    /**
-     * Build one fulfilled-assertion record per pending double (summarising the calls it recorded) plus one
-     * for the deferred `received()` assertions, so a test whose only checks are Double verifications is not
-     * flagged as making no assertions and its report shows what was verified.
-     *
-     * Reads only from the captured snapshot, never throws, and touches no reflection — `received()`
-     * assertions expose no readable detail, so they collapse into a single count.
-     *
-     * @return list<ExpectationFulfilled>
-     */
-    private static function describeVerified(AutoVerifyScope $scope): array
+    private static function ensureListening(): void
     {
-        $records = [];
-        foreach ($scope->pending() as $state) {
-            $records[] = new ExpectationFulfilled(self::describeDouble($state), '');
-        }
-
-        $received = \count($scope->pendingReceived());
-        $received > 0 and $records[] = new ExpectationFulfilled(
-            \sprintf('%d Double received %s verified', $received, $received === 1 ? 'assertion was' : 'assertions were'),
-            '',
-        );
-
-        return $records;
-    }
-
-    /**
-     * A one-line summary of a single double: its label and the methods it recorded calls to, with counts.
-     */
-    private static function describeDouble(DoubleState $state): string
-    {
-        $counts = [];
-        foreach ($state->calls() as $call) {
-            $counts[$call['method']] = ($counts[$call['method']] ?? 0) + 1;
-        }
-
-        if ($counts === []) {
-            return \sprintf('Double `%s` verified with no recorded calls', $state->label());
-        }
-
-        $parts = [];
-        foreach ($counts as $method => $times) {
-            $parts[] = \sprintf('%s()×%d', $method, $times);
-        }
-
-        return \sprintf('Double `%s` verified (%s)', $state->label(), \implode(', ', $parts));
-    }
-
-    /**
-     * Append the fulfilled records to the current test's assertion history.
-     *
-     * No-op without the Assert plugin (the {@see \class_exists()} guard). Runs innermost, before the
-     * Assert plugin reads the history, so the records land on the current test.
-     *
-     * @param list<ExpectationFulfilled> $records
-     */
-    private static function pushHistory(array $records): void
-    {
-        if (!\class_exists(StaticState::class)) {
+        static $listening = false;
+        if ($listening || !\class_exists(StaticState::class)) {
             return;
         }
 
+        $listening = true;
+        Double::listen(self::record(...));
+    }
+
+    /**
+     * Mirror one resolved Double check into the current test's assertion history: a fulfilled record when
+     * it passed, a failed one carrying the diagnostic when it did not.
+     */
+    private static function record(CheckEvent $event): void
+    {
         $state = StaticState::current();
         if ($state === null) {
             return;
         }
 
-        foreach ($records as $record) {
-            $state->history[] = $record;
-        }
-    }
+        $subject = $event->method === null
+            ? \sprintf('Double `%s`', $event->label)
+            : \sprintf('Double `%s`->%s()', $event->label, $event->method);
 
-    /**
-     * Record an unmet Double expectation as a failed assertion on the current test and return it,
-     * so the caller can use the same record as the test's failure.
-     *
-     * Returns null without the Assert plugin — the caller then falls back to the raw Double exception.
-     */
-    private static function reportFailedCheck(\Throwable $e): ?ExpectationFailed
-    {
-        if (!\class_exists(StaticState::class)) {
-            return null;
-        }
-
-        $failure = new ExpectationFailed(
-            expectation: 'the Double expectations are fulfilled',
-            context: '',
-            reason: $e->getMessage(),
-            details: '',
-        );
-
-        $state = StaticState::current();
-        $state === null or $state->history[] = $failure;
-
-        return $failure;
-    }
-
-    /**
-     * Record a Double check that failed inside the test body (surfaced as `$result->failure`) as a failed
-     * assertion on the current test. The result is not modified: the failure is already there, and whether
-     * it fails the test or is absorbed by `#[ExpectException]` is the pipeline's call.
-     *
-     * No-op unless the failure is a Double check failure (see {@see self::CHECK_FAILURES}) and the Assert
-     * plugin is present.
-     */
-    private static function reportBodyFailure(TestResult $result): void
-    {
-        $failure = $result->failure;
-        if ($failure === null || !self::isCheckFailure($failure) || !\class_exists(StaticState::class)) {
-            return;
-        }
-
-        $state = StaticState::current();
-        $state === null or $state->history[] = new ExpectationFailed(
-            expectation: 'the Double checks passed',
-            context: '',
-            reason: $failure->getMessage(),
-            details: '',
-        );
-    }
-
-    private static function isCheckFailure(\Throwable $failure): bool
-    {
-        foreach (self::CHECK_FAILURES as $class) {
-            if ($failure instanceof $class) {
-                return true;
-            }
-        }
-
-        return false;
+        $state->history[] = $event->passed
+            ? new ExpectationFulfilled($subject . ' passed its check', '')
+            : new ExpectationFailed(
+                expectation: $subject . ' passed its check',
+                context: '',
+                reason: $event->failure?->getMessage() ?? '',
+                details: '',
+            );
     }
 
     /**
@@ -237,8 +114,8 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
      *
      * Double's pending doubles live in process-global state, so under concurrent (fiber-based) execution
      * sibling tests would sweep each other's doubles into the wrong teardown. On every suspension we park
-     * this test's state with {@see Double::captureAutoVerifyScope()} and hand a fresh slate to the sibling;
-     * on resumption we reinstall it with {@see Double::restoreAutoVerifyScope()}.
+     * this test's state with {@see Double::pauseAutoVerify()} and hand a fresh slate to the sibling; on
+     * resumption we reinstall it with {@see Double::resumeAutoVerify()}.
      *
      * @param callable(TestInfo): TestResult $next
      */
@@ -251,16 +128,16 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
         $fiber = new \Fiber(static fn(): TestResult => $next($info));
         $value = $fiber->start();
         while (!$fiber->isTerminated()) {
-            $scope = Double::captureAutoVerifyScope();
+            $snapshot = Double::pauseAutoVerify();
             try {
                 $resume = \Fiber::suspend($value);
             } catch (\Throwable $e) {
-                Double::restoreAutoVerifyScope($scope);
+                Double::resumeAutoVerify($snapshot);
                 $value = $fiber->throw($e);
                 continue;
             }
 
-            Double::restoreAutoVerifyScope($scope);
+            Double::resumeAutoVerify($snapshot);
             $value = $fiber->resume($resume);
         }
 

--- a/bridge/double/src/Internal/DoubleInterceptor.php
+++ b/bridge/double/src/Internal/DoubleInterceptor.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace Testo\Bridge\Double\Internal;
 
+use JMac\Testing\AutoVerifyScope;
 use JMac\Testing\Double;
+use JMac\Testing\Engine\DoubleState;
+use JMac\Testing\Exceptions\ExpectationCallLimitExceededException;
+use JMac\Testing\Exceptions\ExpectationCallMismatchException;
+use JMac\Testing\Exceptions\OutOfOrderCallException;
+use JMac\Testing\Exceptions\UnexpectedCallException;
+use JMac\Testing\Exceptions\UnsatisfiedExpectationException;
+use JMac\Testing\Exceptions\UnsatisfiedReceivedAssertionException;
+use JMac\Testing\Exceptions\UnusedAssertionException;
 use Testo\Assert\Internal\StaticState;
 use Testo\Assert\State\Expectation\ExpectationFailed;
 use Testo\Assert\State\Expectation\ExpectationFulfilled;
@@ -17,10 +26,17 @@ use Testo\Pipeline\Middleware\TestRunInterceptor;
 
 /**
  * Arms {@see Double::armAutoVerify()} before every test and runs {@see Double::verifyAll()} afterwards
- * in a `finally` block: unmet `expects()` and deferred `received()` assertions fail the test. `verifyAll()`
- * returns how many checks it performed, which the bridge reports to the Assert plugin so a double-only test
- * still counts as making assertions. It always drains Double's global state, so an unmet expectation fails
- * an otherwise-passing test while an already-failed result is left alone.
+ * in a `finally` block: unmet `expects()` and deferred `received()` assertions fail the test. Before
+ * verifying, the bridge snapshots the pending doubles and reports one fulfilled assertion per double
+ * (with its recorded calls) to the Assert plugin, so a double-only test still counts as making assertions
+ * and its report carries what was checked. It always drains Double's global state, so an unmet expectation
+ * fails an otherwise-passing test while an already-failed result is left alone.
+ *
+ * A Double check that throws inside the test body (a failed `received()`, `unused()` or an unexpected
+ * call on a strict double) is captured by the runner into the result's failure. The bridge records it in
+ * the assertion history so the double's diagnostic stays visible, then passes the result through untouched:
+ * whether the test ends up failed or passes because `#[ExpectException]` caught that throw is decided by
+ * the rest of the pipeline, not here.
  *
  * Runs innermost so the teardown fires as close as possible to the test function.
  *
@@ -44,8 +60,13 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
             $result = $this->run($info, $next);
         } finally {
             try {
-                $verified = Double::verifyAll();
-                $verified > 0 and self::reportVerifiedChecks($verified);
+                # Snapshot the pending doubles before verifying so we can describe each in the test's
+                # assertion history; restore it verbatim so verifyAll() checks exactly the same set.
+                $scope = Double::captureAutoVerifyScope();
+                $records = \class_exists(StaticState::class) ? self::describeVerified($scope) : [];
+                Double::restoreAutoVerifyScope($scope);
+                Double::verifyAll();
+                $records === [] or self::pushHistory($records);
             } catch (\Throwable $e) {
                 # Record the unmet expectation on the test, then turn it into a normal failure — an
                 # exception escaping here would abort the pipeline (Status::Aborted) instead. Leave an
@@ -57,27 +78,98 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
             }
         }
 
+        # A Double check that failed in the test body arrives as the result's failure. Record it, leaving
+        # the result itself untouched so the pipeline still decides the final status (including a pass when
+        # #[ExpectException] catches that throw).
+        $result === null or self::reportBodyFailure($result);
+
         return $result;
     }
 
     /**
-     * Record the `$count` passed Double checks as one fulfilled assertion on the current test, so a test
-     * whose only checks are `expects()` / `received()` verifications is not flagged as making no assertions.
+     * Every Double exception that represents a *check* failing, as opposed to a misuse error (calling an
+     * unknown or static method, misconfiguring a mode). Only these are recorded as a failed check.
+     */
+    private const CHECK_FAILURES = [
+        UnsatisfiedExpectationException::class,
+        UnsatisfiedReceivedAssertionException::class,
+        UnusedAssertionException::class,
+        UnexpectedCallException::class,
+        ExpectationCallLimitExceededException::class,
+        ExpectationCallMismatchException::class,
+        OutOfOrderCallException::class,
+    ];
+
+    /**
+     * Build one fulfilled-assertion record per pending double (summarising the calls it recorded) plus one
+     * for the deferred `received()` assertions, so a test whose only checks are Double verifications is not
+     * flagged as making no assertions and its report shows what was verified.
+     *
+     * Reads only from the captured snapshot, never throws, and touches no reflection — `received()`
+     * assertions expose no readable detail, so they collapse into a single count.
+     *
+     * @return list<ExpectationFulfilled>
+     */
+    private static function describeVerified(AutoVerifyScope $scope): array
+    {
+        $records = [];
+        foreach ($scope->pending() as $state) {
+            $records[] = new ExpectationFulfilled(self::describeDouble($state), '');
+        }
+
+        $received = \count($scope->pendingReceived());
+        $received > 0 and $records[] = new ExpectationFulfilled(
+            \sprintf('%d Double received %s verified', $received, $received === 1 ? 'assertion was' : 'assertions were'),
+            '',
+        );
+
+        return $records;
+    }
+
+    /**
+     * A one-line summary of a single double: its label and the methods it recorded calls to, with counts.
+     */
+    private static function describeDouble(DoubleState $state): string
+    {
+        $counts = [];
+        foreach ($state->calls() as $call) {
+            $counts[$call['method']] = ($counts[$call['method']] ?? 0) + 1;
+        }
+
+        if ($counts === []) {
+            return \sprintf('Double `%s` verified with no recorded calls', $state->label());
+        }
+
+        $parts = [];
+        foreach ($counts as $method => $times) {
+            $parts[] = \sprintf('%s()×%d', $method, $times);
+        }
+
+        return \sprintf('Double `%s` verified (%s)', $state->label(), \implode(', ', $parts));
+    }
+
+    /**
+     * Append the fulfilled records to the current test's assertion history.
      *
      * No-op without the Assert plugin (the {@see \class_exists()} guard). Runs innermost, before the
-     * Assert plugin reads the history, so the record lands on the current test.
+     * Assert plugin reads the history, so the records land on the current test.
+     *
+     * @param list<ExpectationFulfilled> $records
      */
-    private static function reportVerifiedChecks(int $count): void
+    private static function pushHistory(array $records): void
     {
         if (!\class_exists(StaticState::class)) {
             return;
         }
 
         $state = StaticState::current();
-        $state === null or $state->history[] = new ExpectationFulfilled(
-            \sprintf('%d Double %s verified', $count, $count === 1 ? 'check was' : 'checks were'),
-            '',
-        );
+        if ($state === null) {
+            return;
+        }
+
+        foreach ($records as $record) {
+            $state->history[] = $record;
+        }
     }
 
     /**
@@ -103,6 +195,41 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
         $state === null or $state->history[] = $failure;
 
         return $failure;
+    }
+
+    /**
+     * Record a Double check that failed inside the test body (surfaced as `$result->failure`) as a failed
+     * assertion on the current test. The result is not modified: the failure is already there, and whether
+     * it fails the test or is absorbed by `#[ExpectException]` is the pipeline's call.
+     *
+     * No-op unless the failure is a Double check failure (see {@see self::CHECK_FAILURES}) and the Assert
+     * plugin is present.
+     */
+    private static function reportBodyFailure(TestResult $result): void
+    {
+        $failure = $result->failure;
+        if ($failure === null || !self::isCheckFailure($failure) || !\class_exists(StaticState::class)) {
+            return;
+        }
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = new ExpectationFailed(
+            expectation: 'the Double checks passed',
+            context: '',
+            reason: $failure->getMessage(),
+            details: '',
+        );
+    }
+
+    private static function isCheckFailure(\Throwable $failure): bool
+    {
+        foreach (self::CHECK_FAILURES as $class) {
+            if ($failure instanceof $class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/bridge/double/src/Internal/DoubleInterceptor.php
+++ b/bridge/double/src/Internal/DoubleInterceptor.php
@@ -18,17 +18,9 @@ use Testo\Pipeline\Attribute\InterceptorOptions;
 use Testo\Pipeline\Middleware\TestRunInterceptor;
 
 /**
- * Bridges Double's auto-verification into a Testo test.
- *
- * Turns on {@see Double::enableAutoVerify()} before the test body and runs {@see Double::verifyAll()}
- * afterwards in a `finally`: unmet `expects()` and deferred `received()` assertions are checked there, and
- * a failure turns an otherwise-passing test into a failed one (an already-failed result is left alone).
- *
- * A {@see Double::listen()} listener mirrors every check into the Assert plugin's history the moment it
- * resolves, pass or fail, immediate call-time failures included. So a double-only test still counts as
- * making assertions, and the report shows what was checked in the order it happened. The listener only
- * records; it never changes the result, so whether a body-thrown check failure fails the test or is
- * absorbed by `#[ExpectException]` stays the rest of the pipeline's call.
+ * Bridges Double's auto-verification into a Testo test: unmet `expects()` and deferred `received()`
+ * checks fail the test at teardown, and every resolved check is mirrored into the Assert plugin's
+ * history so a double-only test counts as making assertions.
  *
  * Runs innermost so the teardown fires as close as possible to the test function.
  *
@@ -45,8 +37,6 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
     public function runTest(TestInfo $info, callable $next): TestResult
     {
         self::ensureListening();
-
-        # Enable before the test body runs so every double it creates is collected for verification.
         Double::enableAutoVerify();
 
         $result = null;
@@ -84,10 +74,6 @@ final readonly class DoubleInterceptor implements TestRunInterceptor
         Double::listen(self::record(...));
     }
 
-    /**
-     * Mirror one resolved Double check into the current test's assertion history: a fulfilled record when
-     * it passed, a failed one carrying the diagnostic when it did not.
-     */
     private static function record(CheckEvent $event): void
     {
         $state = StaticState::current();

--- a/bridge/double/tests/Acceptance/DoubleBridgeTest.php
+++ b/bridge/double/tests/Acceptance/DoubleBridgeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Acceptance;
+
+use JMac\Testing\Double;
+use JMac\Testing\DoubleInterface;
+use Testo\Assert;
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+/**
+ * Acceptance tests for {@see DoublePlugin}. The suite registers the plugin
+ * (see `bridge/double/tests/suites.php`), so `Double::verifyAll()` fires after
+ * every test. Assertions therefore depend on the plugin doing its job:
+ * expectations are verified on teardown with no per-test `verify()` call.
+ */
+#[Test]
+#[Covers(DoublePlugin::class)]
+#[Covers(DoubleInterceptor::class)]
+final class DoubleBridgeTest
+{
+    public function doubleCreatedAndExpectationFulfilled(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(7);
+
+        Assert::same($double->count(), 7);
+    }
+
+    public function expectedCallCountIsVerifiedOnTeardown(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->times(2)->returns(2);
+
+        $double->count();
+        $double->count();
+    }
+
+    public function spyRecordsCallsWithReceived(): void
+    {
+        /** @var DoubleInterface&\Countable $spy */
+        $spy = Double::for(\Countable::class);
+        $spy->allows('count')->returns(3);
+
+        Assert::same($spy->count(), 3);
+
+        $spy->received('count')->times(1);
+    }
+}

--- a/bridge/double/tests/Acceptance/DoubleBridgeTest.php
+++ b/bridge/double/tests/Acceptance/DoubleBridgeTest.php
@@ -19,7 +19,6 @@ use Testo\Test;
  * expectations are verified on teardown with no per-test `verify()` call.
  */
 #[Test]
-#[Covers(DoublePlugin::class)]
 #[Covers(DoubleInterceptor::class)]
 final class DoubleBridgeTest
 {

--- a/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
+++ b/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Feature;
+
+use Testo\Assert;
+use Testo\Assert\TestState;
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Codecov\Covers;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
+use Testo\Filter\Group;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Helper\TestRunner;
+use Tests\Bridge\Double\Stub\DoubleAssertConcurrencyScenarios;
+use Tests\Bridge\Double\Stub\DoubleExpectConcurrencyScenarios;
+
+/**
+ * The Double bridge must be **transparent** to the rest of the test while tests interleave on the fiber
+ * scheduler: the doubles themselves stay isolated (that is the trampoline's own job), and everything else
+ * the test does — plain `Assert::*` calls, `Expect::exception()` — must keep landing on that test's own
+ * state exactly as it would without Double in the case.
+ *
+ * Each case runs a RoundRobin stub pair through {@see TestRunner} and inspects the per-test results.
+ */
+#[Test]
+#[Group('async')]
+#[Covers(DoublePlugin::class)]
+#[Covers(DoubleInterceptor::class)]
+#[TestingSuite(path: __DIR__ . '/../Stub', plugins: [DoublePlugin::class])]
+final class DoubleInterleaveAttributionTest
+{
+    public function interleavedDoublesStayIsolated(): void
+    {
+        // The trampoline's own concern: each test's expectations verify against its own pending list
+        // even though both tests park mid-double while the other runs.
+        $first = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'firstAssertsAroundItsDouble']);
+        $second = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'secondAssertsAroundItsDouble']);
+
+        Assert::same($first->status, Status::Passed);
+        Assert::same($second->status, Status::Passed);
+    }
+
+    public function bodyAssertionsLandInEachTestsHistory(): void
+    {
+        // Each stub test makes two Assert::same() calls of its own; the bridge adds one record for the
+        // verified double. A transparent bridge leaves all three in the test's history.
+        $first = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'firstAssertsAroundItsDouble']);
+        $second = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'secondAssertsAroundItsDouble']);
+
+        Assert::same(self::historyCount($first), 3, 'first test: 2 body asserts + 1 double verification');
+        Assert::same(self::historyCount($second), 3, 'second test: 2 body asserts + 1 double verification');
+    }
+
+    public function expectExceptionSurvivesTheInterleave(): void
+    {
+        // Each stub test declares Expect::exception() up front and throws after its yield — with a
+        // transparent bridge both expectations are fulfilled and both tests pass.
+        $first = TestRunner::runTest([DoubleExpectConcurrencyScenarios::class, 'firstExpectsItsException']);
+        $second = TestRunner::runTest([DoubleExpectConcurrencyScenarios::class, 'secondExpectsItsException']);
+
+        Assert::same($first->status, Status::Passed);
+        Assert::same($second->status, Status::Passed);
+    }
+
+    private static function historyCount(TestResult $result): int
+    {
+        $state = $result->getAttribute(TestState::class);
+
+        return $state instanceof TestState ? \count($state->history) : -1;
+    }
+}

--- a/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
+++ b/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
@@ -19,12 +19,9 @@ use Tests\Bridge\Double\Stub\DoubleAssertConcurrencyScenarios;
 use Tests\Bridge\Double\Stub\DoubleExpectConcurrencyScenarios;
 
 /**
- * The Double bridge must be **transparent** to the rest of the test while tests interleave on the fiber
- * scheduler: the doubles themselves stay isolated (that is the trampoline's own job), and everything else
- * the test does — plain `Assert::*` calls, `Expect::exception()` — must keep landing on that test's own
- * state exactly as it would without Double in the case.
- *
- * Each case runs a RoundRobin stub pair through {@see TestRunner} and inspects the per-test results.
+ * While tests interleave on the fiber scheduler, plain `Assert::*` calls and `Expect::exception()` must
+ * keep landing on their own test's state as if Double were not in the case. Each case runs a RoundRobin
+ * stub pair through {@see TestRunner}.
  */
 #[Test]
 #[Group('async')]
@@ -35,8 +32,6 @@ final class DoubleInterleaveAttributionTest
 {
     public function interleavedDoublesStayIsolated(): void
     {
-        // The trampoline's own concern: each test's expectations verify against its own pending list
-        // even though both tests park mid-double while the other runs.
         $first = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'firstAssertsAroundItsDouble']);
         $second = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'secondAssertsAroundItsDouble']);
 
@@ -46,8 +41,6 @@ final class DoubleInterleaveAttributionTest
 
     public function bodyAssertionsLandInEachTestsHistory(): void
     {
-        // Each stub test makes two Assert::same() calls of its own; the bridge adds one record for the
-        // verified double. A transparent bridge leaves all three in the test's history.
         $first = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'firstAssertsAroundItsDouble']);
         $second = TestRunner::runTest([DoubleAssertConcurrencyScenarios::class, 'secondAssertsAroundItsDouble']);
 
@@ -57,8 +50,6 @@ final class DoubleInterleaveAttributionTest
 
     public function expectExceptionSurvivesTheInterleave(): void
     {
-        // Each stub test declares Expect::exception() up front and throws after its yield — with a
-        // transparent bridge both expectations are fulfilled and both tests pass.
         $first = TestRunner::runTest([DoubleExpectConcurrencyScenarios::class, 'firstExpectsItsException']);
         $second = TestRunner::runTest([DoubleExpectConcurrencyScenarios::class, 'secondExpectsItsException']);
 

--- a/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
+++ b/bridge/double/tests/Feature/DoubleInterleaveAttributionTest.php
@@ -25,7 +25,6 @@ use Tests\Bridge\Double\Stub\DoubleExpectConcurrencyScenarios;
  */
 #[Test]
 #[Group('async')]
-#[Covers(DoublePlugin::class)]
 #[Covers(DoubleInterceptor::class)]
 #[TestingSuite(path: __DIR__ . '/../Stub', plugins: [DoublePlugin::class])]
 final class DoubleInterleaveAttributionTest

--- a/bridge/double/tests/Feature/DoubleStatusTest.php
+++ b/bridge/double/tests/Feature/DoubleStatusTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Feature;
+
+use Testo\Assert;
+use Testo\Assert\TestState;
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Codecov\Covers;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Value\Status;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Helper\TestRunner;
+use Tests\Bridge\Double\Stub\DoubleResetScenarios;
+use Tests\Bridge\Double\Stub\DoubleScenarios;
+
+/**
+ * How the Double bridge maps double verification onto Testo's test statuses. Each case runs a stub
+ * scenario through {@see TestRunner} (with {@see DoublePlugin} loaded) and asserts the resulting
+ * {@see Status} — the surface a user sees in the report.
+ */
+#[Test]
+#[Covers(DoublePlugin::class)]
+#[Covers(DoubleInterceptor::class)]
+#[TestingSuite(path: __DIR__ . '/../Stub', plugins: [DoublePlugin::class])]
+final class DoubleStatusTest
+{
+    public function fulfilledExpectationCountsAsAssertion(): void
+    {
+        $result = TestRunner::runTest([DoubleScenarios::class, 'fulfilledExpectationOnly']);
+        Assert::same($result->status, Status::Passed);
+        Assert::true(self::hasRecord($result, success: true));
+    }
+
+    public function unfulfilledExpectationFailsTheTest(): void
+    {
+        $result = TestRunner::runTest([DoubleScenarios::class, 'unfulfilledExpectation']);
+        Assert::same($result->status, Status::Failed);
+        Assert::true(self::hasRecord($result, success: false));
+    }
+
+    public function noDoublesNoAssertionsStaysRisky(): void
+    {
+        $result = TestRunner::runTest([DoubleScenarios::class, 'noDoublesNoAssertions']);
+        Assert::same($result->status, Status::Risky);
+    }
+
+    public function receivedVerificationCountsAsAssertion(): void
+    {
+        $result = TestRunner::runTest([DoubleScenarios::class, 'receivedVerificationOnly']);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    public function doubleAndAssertCoexist(): void
+    {
+        $result = TestRunner::runTest([DoubleScenarios::class, 'doubleAndAssertMixed']);
+        Assert::same($result->status, Status::Passed);
+    }
+
+    public function stateIsDrainedAfterAFailingTest(): void
+    {
+        // leavesUnmetExpectation fails on verifyAll(); seesCleanSlate runs right after it and would
+        // fail too if that unmet expectation had leaked into the global pending list. Both statuses
+        // being as expected proves the drain happens on the failure path, not only when a test passes.
+        $failed = TestRunner::runTest([DoubleResetScenarios::class, 'leavesUnmetExpectation']);
+        Assert::same($failed->status, Status::Failed);
+
+        $next = TestRunner::runTest([DoubleResetScenarios::class, 'seesCleanSlate']);
+        Assert::same($next->status, Status::Passed);
+    }
+
+    /**
+     * Whether the test's assertion history holds a record with the given success flag — i.e. the
+     * bridge reported the double verification (fulfilled or failed) to the Assert plugin.
+     */
+    private static function hasRecord(TestResult $result, bool $success): bool
+    {
+        $state = $result->getAttribute(TestState::class);
+        if (!$state instanceof TestState) {
+            return false;
+        }
+
+        foreach ($state->history as $record) {
+            if ($record->isSuccess() === $success) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/bridge/double/tests/Feature/DoubleStatusTest.php
+++ b/bridge/double/tests/Feature/DoubleStatusTest.php
@@ -54,19 +54,46 @@ final class DoubleStatusTest
         Assert::same($result->status, Status::Passed);
     }
 
-    public function verifiedRecordNamesTheDoubleAndItsCalls(): void
+    public function verifiedChecksNameTheDoubleAndMethod(): void
     {
-        // The fulfilled record carries the double's label and a per-method call summary, not just a count.
-        $result = TestRunner::runTest([DoubleScenarios::class, 'fulfilledExpectationOnly']);
-        Assert::string(self::successExpectation($result))
-            ->contains('Countable')
-            ->contains('count()×1');
+        // Each recorded check names its double, and a received() check names the method it verified.
+        $result = TestRunner::runTest([DoubleScenarios::class, 'receivedVerificationOnly']);
+        Assert::string(self::successExpectations($result))
+            ->contains('Double `Countable`')
+            ->contains('count()');
     }
 
     public function doubleAndAssertCoexist(): void
     {
         $result = TestRunner::runTest([DoubleScenarios::class, 'doubleAndAssertMixed']);
         Assert::same($result->status, Status::Passed);
+    }
+
+    public function checksAreRecordedInChronologicalOrder(): void
+    {
+        // The scenario asserts, runs a passing Double check, then asserts again. Because checks are recorded
+        // the moment they resolve (not batched at teardown), a plain assertion lands after the Double check
+        // in the history.
+        $result = TestRunner::runTest([DoubleScenarios::class, 'checkInterleavesWithAssertions']);
+        $order = self::orderedExpectations($result);
+
+        $firstDouble = null;
+        foreach ($order as $i => $expectation) {
+            if (\str_contains($expectation, 'Double `')) {
+                $firstDouble = $i;
+                break;
+            }
+        }
+        Assert::true($firstDouble !== null, 'a Double check was recorded');
+
+        $assertionAfterDouble = false;
+        foreach ($order as $i => $expectation) {
+            if ($i > $firstDouble && !\str_contains($expectation, 'Double `')) {
+                $assertionAfterDouble = true;
+                break;
+            }
+        }
+        Assert::true($assertionAfterDouble, 'a plain assertion is recorded after a Double check');
     }
 
     public function bodyCheckFailureIsRecordedButResultLeftAsIs(): void
@@ -113,22 +140,39 @@ final class DoubleStatusTest
     }
 
     /**
-     * The expectation text of the test's first fulfilled (success) assertion record, or '' if none.
+     * The rendered text of every assertion record, in the order they were recorded.
+     *
+     * @return list<string>
      */
-    private static function successExpectation(TestResult $result): string
+    private static function orderedExpectations(TestResult $result): array
+    {
+        $state = $result->getAttribute(TestState::class);
+        if (!$state instanceof TestState) {
+            return [];
+        }
+
+        return \array_map(
+            static fn(\Stringable $record): string => (string) $record,
+            $state->history,
+        );
+    }
+
+    /**
+     * The expectation texts of every fulfilled (success) assertion record, joined by newlines.
+     */
+    private static function successExpectations(TestResult $result): string
     {
         $state = $result->getAttribute(TestState::class);
         if (!$state instanceof TestState) {
             return '';
         }
 
+        $expectations = [];
         foreach ($state->history as $record) {
-            if ($record->isSuccess()) {
-                return $record->getExpectation();
-            }
+            $record->isSuccess() and $expectations[] = (string) $record;
         }
 
-        return '';
+        return \implode("\n", $expectations);
     }
 
     /**

--- a/bridge/double/tests/Feature/DoubleStatusTest.php
+++ b/bridge/double/tests/Feature/DoubleStatusTest.php
@@ -54,10 +54,30 @@ final class DoubleStatusTest
         Assert::same($result->status, Status::Passed);
     }
 
+    public function verifiedRecordNamesTheDoubleAndItsCalls(): void
+    {
+        // The fulfilled record carries the double's label and a per-method call summary, not just a count.
+        $result = TestRunner::runTest([DoubleScenarios::class, 'fulfilledExpectationOnly']);
+        Assert::string(self::successExpectation($result))
+            ->contains('Countable')
+            ->contains('count()×1');
+    }
+
     public function doubleAndAssertCoexist(): void
     {
         $result = TestRunner::runTest([DoubleScenarios::class, 'doubleAndAssertMixed']);
         Assert::same($result->status, Status::Passed);
+    }
+
+    public function bodyCheckFailureIsRecordedButResultLeftAsIs(): void
+    {
+        // A Double check that throws in the body (here: unused() on a called spy) with no #[ExpectException]
+        // to catch it: the bridge records the failure in the history but does not touch the result, so it
+        // stays the Error the runner produced from the uncaught throw.
+        $result = TestRunner::runTest([DoubleScenarios::class, 'bodyCheckFailsUncaught']);
+        Assert::same($result->status, Status::Error);
+        Assert::true(self::hasRecord($result, success: false));
+        Assert::string(self::failReason($result))->contains('expected no calls');
     }
 
     public function stateIsDrainedAfterAFailingTest(): void
@@ -90,5 +110,43 @@ final class DoubleStatusTest
         }
 
         return false;
+    }
+
+    /**
+     * The expectation text of the test's first fulfilled (success) assertion record, or '' if none.
+     */
+    private static function successExpectation(TestResult $result): string
+    {
+        $state = $result->getAttribute(TestState::class);
+        if (!$state instanceof TestState) {
+            return '';
+        }
+
+        foreach ($state->history as $record) {
+            if ($record->isSuccess()) {
+                return $record->getExpectation();
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * The fail reason of the test's first failed (unsuccessful) assertion record, or '' if none.
+     */
+    private static function failReason(TestResult $result): string
+    {
+        $state = $result->getAttribute(TestState::class);
+        if (!$state instanceof TestState) {
+            return '';
+        }
+
+        foreach ($state->history as $record) {
+            if (!$record->isSuccess()) {
+                return $record->getFailReason();
+            }
+        }
+
+        return '';
     }
 }

--- a/bridge/double/tests/Feature/DoubleStatusTest.php
+++ b/bridge/double/tests/Feature/DoubleStatusTest.php
@@ -23,7 +23,6 @@ use Tests\Bridge\Double\Stub\DoubleScenarios;
  * {@see Status} — the surface a user sees in the report.
  */
 #[Test]
-#[Covers(DoublePlugin::class)]
 #[Covers(DoubleInterceptor::class)]
 #[TestingSuite(path: __DIR__ . '/../Stub', plugins: [DoublePlugin::class])]
 final class DoubleStatusTest

--- a/bridge/double/tests/Feature/DoubleStatusTest.php
+++ b/bridge/double/tests/Feature/DoubleStatusTest.php
@@ -56,7 +56,6 @@ final class DoubleStatusTest
 
     public function verifiedChecksNameTheDoubleAndMethod(): void
     {
-        // Each recorded check names its double, and a received() check names the method it verified.
         $result = TestRunner::runTest([DoubleScenarios::class, 'receivedVerificationOnly']);
         Assert::string(self::successExpectations($result))
             ->contains('Double `Countable`')
@@ -71,9 +70,7 @@ final class DoubleStatusTest
 
     public function checksAreRecordedInChronologicalOrder(): void
     {
-        // The scenario asserts, runs a passing Double check, then asserts again. Because checks are recorded
-        // the moment they resolve (not batched at teardown), a plain assertion lands after the Double check
-        // in the history.
+        // Checks are recorded the moment they resolve, not batched at teardown.
         $result = TestRunner::runTest([DoubleScenarios::class, 'checkInterleavesWithAssertions']);
         $order = self::orderedExpectations($result);
 
@@ -98,9 +95,7 @@ final class DoubleStatusTest
 
     public function bodyCheckFailureIsRecordedButResultLeftAsIs(): void
     {
-        // A Double check that throws in the body (here: unused() on a called spy) with no #[ExpectException]
-        // to catch it: the bridge records the failure in the history but does not touch the result, so it
-        // stays the Error the runner produced from the uncaught throw.
+        // The bridge records a body-thrown check failure but leaves the runner's Error result untouched.
         $result = TestRunner::runTest([DoubleScenarios::class, 'bodyCheckFailsUncaught']);
         Assert::same($result->status, Status::Error);
         Assert::true(self::hasRecord($result, success: false));
@@ -109,9 +104,7 @@ final class DoubleStatusTest
 
     public function stateIsDrainedAfterAFailingTest(): void
     {
-        // leavesUnmetExpectation fails on verifyAll(); seesCleanSlate runs right after it and would
-        // fail too if that unmet expectation had leaked into the global pending list. Both statuses
-        // being as expected proves the drain happens on the failure path, not only when a test passes.
+        // The second test would fail too if the first one's unmet expectation leaked past the failure path.
         $failed = TestRunner::runTest([DoubleResetScenarios::class, 'leavesUnmetExpectation']);
         Assert::same($failed->status, Status::Failed);
 
@@ -119,10 +112,6 @@ final class DoubleStatusTest
         Assert::same($next->status, Status::Passed);
     }
 
-    /**
-     * Whether the test's assertion history holds a record with the given success flag — i.e. the
-     * bridge reported the double verification (fulfilled or failed) to the Assert plugin.
-     */
     private static function hasRecord(TestResult $result, bool $success): bool
     {
         $state = $result->getAttribute(TestState::class);
@@ -140,8 +129,6 @@ final class DoubleStatusTest
     }
 
     /**
-     * The rendered text of every assertion record, in the order they were recorded.
-     *
      * @return list<string>
      */
     private static function orderedExpectations(TestResult $result): array
@@ -157,9 +144,6 @@ final class DoubleStatusTest
         );
     }
 
-    /**
-     * The expectation texts of every fulfilled (success) assertion record, joined by newlines.
-     */
     private static function successExpectations(TestResult $result): string
     {
         $state = $result->getAttribute(TestState::class);
@@ -175,9 +159,6 @@ final class DoubleStatusTest
         return \implode("\n", $expectations);
     }
 
-    /**
-     * The fail reason of the test's first failed (unsuccessful) assertion record, or '' if none.
-     */
     private static function failReason(TestResult $result): string
     {
         $state = $result->getAttribute(TestState::class);

--- a/bridge/double/tests/Self/DoubleAndAssertCombinations.php
+++ b/bridge/double/tests/Self/DoubleAndAssertCombinations.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Tests\Bridge\Double\Self;
 
 use JMac\Testing\Double;
+use JMac\Testing\Exceptions\ExpectationCallLimitExceededException;
+use JMac\Testing\Exceptions\UnexpectedCallException;
+use JMac\Testing\Exceptions\UnusedAssertionException;
 use Testo\Assert;
+use Testo\Assert\ExpectException;
 use Testo\Bridge\Double\DoublePlugin;
 use Testo\Bridge\Double\Internal\DoubleInterceptor;
 use Testo\Codecov\Covers;
@@ -82,6 +86,49 @@ final class DoubleAndAssertCombinations
         $double->expects('count')->throws(new \RuntimeException('boom'));
 
         Expect::exception(\RuntimeException::class)->withMessageContaining('boom');
+        $double->count();
+    }
+
+    #[ExpectException(UnusedAssertionException::class)]
+    public function unusedAssertionThrowsAndIsCaught(): void
+    {
+        $double = Double::for(\Countable::class);
+        $double->allows('count')->returns(0);
+        $double->count();
+
+        // A Double check that fails in the test body (here: unused() on a called double) throws like any
+        // other exception, so #[ExpectException] catches it. Unlike an unmet expects(), which surfaces only
+        // from the teardown verifyAll() and leaves nothing for the attribute to see.
+        $double->unused();
+    }
+
+    #[ExpectException(UnexpectedCallException::class)]
+    public function strictUnexpectedCallThrowsAndIsCaught(): void
+    {
+        // A strict double rejects any call it was not configured for, right at the call site.
+        $double = Double::for(\Countable::class)->strict();
+
+        $double->count();
+    }
+
+    #[ExpectException(ExpectationCallLimitExceededException::class)]
+    public function neverExpectationExceededThrowsAndIsCaught(): void
+    {
+        // never() allows zero calls; the first call breaks the limit at the call site.
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->never();
+
+        $double->count();
+    }
+
+    #[ExpectException(ExpectationCallLimitExceededException::class)]
+    public function callCountExceededThrowsAndIsCaught(): void
+    {
+        // times(1) allows a single call; the second call exceeds the limit at the call site.
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->times(1)->returns(0);
+
+        $double->count();
         $double->count();
     }
 }

--- a/bridge/double/tests/Self/DoubleAndAssertCombinations.php
+++ b/bridge/double/tests/Self/DoubleAndAssertCombinations.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Self;
+
+use JMac\Testing\Double;
+use Testo\Assert;
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Codecov\Covers;
+use Testo\Expect;
+use Testo\Test;
+
+/**
+ * Self tests: each method mixes Double expectations with Testo assertions and MUST finish Passed —
+ * a Passed status is the proof that the bridge and the Assert plugin coexist.
+ *
+ * Negative cases (an unmet expectation must fail the test) live in the Feature suite: that failure
+ * surfaces from `verifyAll()` after the method returns and cannot be observed with `Expect`.
+ */
+#[Test]
+#[Covers(DoublePlugin::class)]
+#[Covers(DoubleInterceptor::class)]
+final class DoubleAndAssertCombinations
+{
+    public function assertOnly(): void
+    {
+        Assert::same(1 + 1, 2);
+    }
+
+    public function expectationOnly(): void
+    {
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(3);
+
+        $double->count();
+    }
+
+    public function expectationThenAssert(): void
+    {
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(9);
+
+        Assert::same($double->count(), 9);
+        Assert::instanceOf($double, \Countable::class);
+    }
+
+    public function multipleDoublesAndAsserts(): void
+    {
+        $counter = Double::for(\Countable::class);
+        $counter->expects('count')->times(2)->returns(1);
+        $other = Double::for(\Countable::class);
+        $other->expects('count')->returns(4);
+
+        Assert::same($counter->count(), 1);
+        $counter->count();
+        Assert::same($other->count(), 4);
+    }
+
+    public function spyWithAssert(): void
+    {
+        $spy = Double::for(\Countable::class);
+        $spy->allows('count')->returns(7);
+
+        Assert::same($spy->count(), 7);
+
+        $spy->received('count')->times(1);
+    }
+
+    public function looseStubWithAssert(): void
+    {
+        $stub = Double::for(\Countable::class);
+        $stub->allows('count')->returns(0);
+
+        Assert::same($stub->count(), 0);
+    }
+
+    public function doubleThrowsWithExpectException(): void
+    {
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->throws(new \RuntimeException('boom'));
+
+        Expect::exception(\RuntimeException::class)->withMessageContaining('boom');
+        $double->count();
+    }
+}

--- a/bridge/double/tests/Self/DoubleAndAssertCombinations.php
+++ b/bridge/double/tests/Self/DoubleAndAssertCombinations.php
@@ -96,16 +96,13 @@ final class DoubleAndAssertCombinations
         $double->allows('count')->returns(0);
         $double->count();
 
-        // A Double check that fails in the test body (here: unused() on a called double) throws like any
-        // other exception, so #[ExpectException] catches it. Unlike an unmet expects(), which surfaces only
-        // from the teardown verifyAll() and leaves nothing for the attribute to see.
+        // A check failing in the body throws at the call site, so #[ExpectException] sees it.
         $double->unused();
     }
 
     #[ExpectException(UnexpectedCallException::class)]
     public function strictUnexpectedCallThrowsAndIsCaught(): void
     {
-        // A strict double rejects any call it was not configured for, right at the call site.
         $double = Double::for(\Countable::class)->strict();
 
         $double->count();
@@ -114,7 +111,6 @@ final class DoubleAndAssertCombinations
     #[ExpectException(ExpectationCallLimitExceededException::class)]
     public function neverExpectationExceededThrowsAndIsCaught(): void
     {
-        // never() allows zero calls; the first call breaks the limit at the call site.
         $double = Double::for(\Countable::class);
         $double->expects('count')->never();
 
@@ -124,7 +120,6 @@ final class DoubleAndAssertCombinations
     #[ExpectException(ExpectationCallLimitExceededException::class)]
     public function callCountExceededThrowsAndIsCaught(): void
     {
-        // times(1) allows a single call; the second call exceeds the limit at the call site.
         $double = Double::for(\Countable::class);
         $double->expects('count')->times(1)->returns(0);
 

--- a/bridge/double/tests/Self/DoubleAndAssertCombinations.php
+++ b/bridge/double/tests/Self/DoubleAndAssertCombinations.php
@@ -11,7 +11,6 @@ use JMac\Testing\Exceptions\UnusedAssertionException;
 use Testo\Assert;
 use Testo\Assert\ExpectException;
 use Testo\Assert\Internal\StaticState;
-use Testo\Bridge\Double\DoublePlugin;
 use Testo\Bridge\Double\Internal\DoubleInterceptor;
 use Testo\Codecov\Covers;
 use Testo\Expect;
@@ -25,7 +24,6 @@ use Testo\Test;
  * surfaces from `verifyAll()` after the method returns and cannot be observed with `Expect`.
  */
 #[Test]
-#[Covers(DoublePlugin::class)]
 #[Covers(DoubleInterceptor::class)]
 final class DoubleAndAssertCombinations
 {

--- a/bridge/double/tests/Self/DoubleAndAssertCombinations.php
+++ b/bridge/double/tests/Self/DoubleAndAssertCombinations.php
@@ -10,6 +10,7 @@ use JMac\Testing\Exceptions\UnexpectedCallException;
 use JMac\Testing\Exceptions\UnusedAssertionException;
 use Testo\Assert;
 use Testo\Assert\ExpectException;
+use Testo\Assert\Internal\StaticState;
 use Testo\Bridge\Double\DoublePlugin;
 use Testo\Bridge\Double\Internal\DoubleInterceptor;
 use Testo\Codecov\Covers;
@@ -70,6 +71,28 @@ final class DoubleAndAssertCombinations
         Assert::same($spy->count(), 7);
 
         $spy->received('count')->times(1);
+    }
+
+    public function checkResolvingWithNoActiveStateIsDropped(): void
+    {
+        $spy = Double::for(\Countable::class);
+        $spy->allows('count')->returns(0);
+
+        $state = StaticState::current();
+        Assert::notNull($state);
+        $before = \count($state->history);
+
+        // The listener is process-wide, so a check can resolve with no test's collector swapped in
+        // (a coroutine relayed out, another suite tearing down). It must be dropped, not appended to a
+        // stale collector nor dereference the null. unused() resolves its CheckEvent synchronously.
+        $restore = StaticState::swap(null);
+        try {
+            $spy->unused();
+        } finally {
+            StaticState::swap($restore);
+        }
+
+        Assert::same(\count($state->history), $before);
     }
 
     public function looseStubWithAssert(): void

--- a/bridge/double/tests/Self/DoubleUnderFibersTest.php
+++ b/bridge/double/tests/Self/DoubleUnderFibersTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Self;
+
+use JMac\Testing\Double;
+use JMac\Testing\DoubleInterface;
+use Revolt\EventLoop;
+use Testo\Assert;
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Bridge\Revolt\RunInRevolt;
+use Testo\Codecov\Covers;
+use Testo\Fiber\RunInFiber;
+use Testo\Filter\Group;
+use Testo\Test;
+
+/**
+ * Double under one-at-a-time fiber execution. A double set up inside a scheduler fiber (Solo) and one
+ * carried across a real Revolt await both verify normally: with no sibling test running, the
+ * process-global pending list stays this test's throughout.
+ */
+#[Test]
+#[Group('async')]
+#[Covers(DoublePlugin::class)]
+#[Covers(DoubleInterceptor::class)]
+final class DoubleUnderFibersTest
+{
+    #[RunInFiber]
+    public function doubleVerifiesInsideASoloFiber(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(4);
+
+        Assert::same($double->count(), 4);
+    }
+
+    #[RunInRevolt]
+    public function doubleVerifiesAcrossARevoltAwait(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(7);
+
+        $suspension = EventLoop::getSuspension();
+        EventLoop::delay(0.001, static fn() => $suspension->resume());
+        $suspension->suspend();
+
+        Assert::same($double->count(), 7);
+    }
+}

--- a/bridge/double/tests/Self/DoubleUnderFibersTest.php
+++ b/bridge/double/tests/Self/DoubleUnderFibersTest.php
@@ -8,7 +8,6 @@ use JMac\Testing\Double;
 use JMac\Testing\DoubleInterface;
 use Revolt\EventLoop;
 use Testo\Assert;
-use Testo\Bridge\Double\DoublePlugin;
 use Testo\Bridge\Double\Internal\DoubleInterceptor;
 use Testo\Bridge\Revolt\RunInRevolt;
 use Testo\Codecov\Covers;
@@ -23,7 +22,6 @@ use Testo\Test;
  */
 #[Test]
 #[Group('async')]
-#[Covers(DoublePlugin::class)]
 #[Covers(DoubleInterceptor::class)]
 final class DoubleUnderFibersTest
 {

--- a/bridge/double/tests/Stub/DoubleAssertConcurrencyScenarios.php
+++ b/bridge/double/tests/Stub/DoubleAssertConcurrencyScenarios.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Stub;
+
+use JMac\Testing\Double;
+use JMac\Testing\DoubleInterface;
+use Testo\Assert;
+use Testo\Fiber\RunInFiber;
+use Testo\Fiber\Schedule;
+use Testo\Test;
+
+/**
+ * Two Double tests interleaving on Testo's fiber scheduler ({@see Schedule::RoundRobin}), each making
+ * plain `Assert::*` calls in its body — one before the yield, one after. If the bridge is transparent,
+ * every test's history holds all of its own assertions plus the bridge's double-verification record.
+ *
+ * Driven through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
+ */
+#[Test]
+#[RunInFiber(Schedule::RoundRobin)]
+final class DoubleAssertConcurrencyScenarios
+{
+    public function firstAssertsAroundItsDouble(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(1);
+
+        Assert::same(1, 1);
+
+        \Fiber::suspend();
+
+        Assert::same($double->count(), 1);
+    }
+
+    public function secondAssertsAroundItsDouble(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(2);
+
+        Assert::same(2, 2);
+
+        \Fiber::suspend();
+
+        Assert::same($double->count(), 2);
+    }
+}

--- a/bridge/double/tests/Stub/DoubleAssertConcurrencyScenarios.php
+++ b/bridge/double/tests/Stub/DoubleAssertConcurrencyScenarios.php
@@ -12,10 +12,7 @@ use Testo\Fiber\Schedule;
 use Testo\Test;
 
 /**
- * Two Double tests interleaving on Testo's fiber scheduler ({@see Schedule::RoundRobin}), each making
- * plain `Assert::*` calls in its body — one before the yield, one after. If the bridge is transparent,
- * every test's history holds all of its own assertions plus the bridge's double-verification record.
- *
+ * Two Double tests interleaving on {@see Schedule::RoundRobin}, each asserting before and after its yield.
  * Driven through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
  */
 #[Test]

--- a/bridge/double/tests/Stub/DoubleExpectConcurrencyScenarios.php
+++ b/bridge/double/tests/Stub/DoubleExpectConcurrencyScenarios.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Stub;
+
+use JMac\Testing\Double;
+use JMac\Testing\DoubleInterface;
+use Testo\Expect;
+use Testo\Fiber\RunInFiber;
+use Testo\Fiber\Schedule;
+use Testo\Test;
+
+/**
+ * Two Double tests interleaving on Testo's fiber scheduler ({@see Schedule::RoundRobin}), each declaring
+ * an expected exception up front and throwing it after the yield. If the bridge is transparent, both pass:
+ * the expectation is registered on the test's own double and the throw satisfies the declared exception.
+ *
+ * Driven through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
+ */
+#[Test]
+#[RunInFiber(Schedule::RoundRobin)]
+final class DoubleExpectConcurrencyScenarios
+{
+    public function firstExpectsItsException(): never
+    {
+        Expect::exception(\DomainException::class);
+
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(1);
+
+        \Fiber::suspend();
+
+        $double->count();
+        throw new \DomainException('first');
+    }
+
+    public function secondExpectsItsException(): never
+    {
+        Expect::exception(\DomainException::class);
+
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(2);
+
+        \Fiber::suspend();
+
+        $double->count();
+        throw new \DomainException('second');
+    }
+}

--- a/bridge/double/tests/Stub/DoubleExpectConcurrencyScenarios.php
+++ b/bridge/double/tests/Stub/DoubleExpectConcurrencyScenarios.php
@@ -12,11 +12,8 @@ use Testo\Fiber\Schedule;
 use Testo\Test;
 
 /**
- * Two Double tests interleaving on Testo's fiber scheduler ({@see Schedule::RoundRobin}), each declaring
- * an expected exception up front and throwing it after the yield. If the bridge is transparent, both pass:
- * the expectation is registered on the test's own double and the throw satisfies the declared exception.
- *
- * Driven through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
+ * Two Double tests interleaving on {@see Schedule::RoundRobin}, each expecting an exception it throws
+ * after its yield. Driven through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
  */
 #[Test]
 #[RunInFiber(Schedule::RoundRobin)]

--- a/bridge/double/tests/Stub/DoubleResetScenarios.php
+++ b/bridge/double/tests/Stub/DoubleResetScenarios.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Stub;
+
+use JMac\Testing\Double;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * A failing test followed by a clean-slate check, run in declaration order through
+ * {@see \Testo\Testing\Helper\TestRunner}: proves the interceptor drains Double's pending state even
+ * when a test fails, so the next test's own expectation is the only one verified.
+ */
+final class DoubleResetScenarios
+{
+    #[Test]
+    public function leavesUnmetExpectation(): void
+    {
+        $double = Double::for(\Countable::class);
+        $double->expects('count');
+    }
+
+    #[Test]
+    public function seesCleanSlate(): void
+    {
+        // If the previous test's unmet expectation had leaked, verifyAll() would fail this test too.
+        // This double's own expectation is fulfilled, so a Passed status proves the slate was drained.
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(1);
+
+        Assert::same($double->count(), 1);
+    }
+}

--- a/bridge/double/tests/Stub/DoubleResetScenarios.php
+++ b/bridge/double/tests/Stub/DoubleResetScenarios.php
@@ -25,8 +25,6 @@ final class DoubleResetScenarios
     #[Test]
     public function seesCleanSlate(): void
     {
-        // If the previous test's unmet expectation had leaked, verifyAll() would fail this test too.
-        // This double's own expectation is fulfilled, so a Passed status proves the slate was drained.
         $double = Double::for(\Countable::class);
         $double->expects('count')->returns(1);
 

--- a/bridge/double/tests/Stub/DoubleScenarios.php
+++ b/bridge/double/tests/Stub/DoubleScenarios.php
@@ -58,4 +58,15 @@ final class DoubleScenarios
 
         Assert::same($double->count(), 5);
     }
+
+    #[Test]
+    public function bodyCheckFailsUncaught(): void
+    {
+        /** @var DoubleInterface&\Countable $spy */
+        $spy = Double::for(\Countable::class);
+        $spy->allows('count')->returns(0);
+        $spy->count();
+
+        $spy->unused();
+    }
 }

--- a/bridge/double/tests/Stub/DoubleScenarios.php
+++ b/bridge/double/tests/Stub/DoubleScenarios.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Stub;
+
+use JMac\Testing\Double;
+use JMac\Testing\DoubleInterface;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Stub tests exercised through {@see \Testo\Testing\Helper\TestRunner} by the Feature suite.
+ * They are not discovered directly (the Stub directory is not a suite location); each method is
+ * a scenario whose reported {@see \Testo\Core\Value\Status} the Feature test asserts on.
+ */
+final class DoubleScenarios
+{
+    #[Test]
+    public function fulfilledExpectationOnly(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(1);
+
+        $double->count();
+    }
+
+    #[Test]
+    public function unfulfilledExpectation(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count');
+    }
+
+    #[Test]
+    public function noDoublesNoAssertions(): void {}
+
+    #[Test]
+    public function receivedVerificationOnly(): void
+    {
+        /** @var DoubleInterface&\Countable $spy */
+        $spy = Double::for(\Countable::class);
+        $spy->allows('count')->returns(0);
+
+        $spy->count();
+
+        $spy->received('count')->times(1);
+    }
+
+    #[Test]
+    public function doubleAndAssertMixed(): void
+    {
+        /** @var DoubleInterface&\Countable $double */
+        $double = Double::for(\Countable::class);
+        $double->expects('count')->returns(5);
+
+        Assert::same($double->count(), 5);
+    }
+}

--- a/bridge/double/tests/Stub/DoubleScenarios.php
+++ b/bridge/double/tests/Stub/DoubleScenarios.php
@@ -69,4 +69,15 @@ final class DoubleScenarios
 
         $spy->unused();
     }
+
+    #[Test]
+    public function checkInterleavesWithAssertions(): void
+    {
+        /** @var DoubleInterface&\Countable $spy */
+        $spy = Double::for(\Countable::class);
+
+        Assert::same(1, 1);
+        $spy->unused(); // passes immediately (never called), recorded here rather than at teardown
+        Assert::same(2, 2);
+    }
 }

--- a/bridge/double/tests/Unit/DoublePluginTest.php
+++ b/bridge/double/tests/Unit/DoublePluginTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\Double\Unit;
+
+use Testo\Bridge\Double\DoublePlugin;
+use Testo\Bridge\Double\Internal\DoubleInterceptor;
+use Testo\Codecov\Covers;
+use Testo\Test;
+use Testo\Testing\Helper\PluginTester;
+
+/**
+ * What {@see DoublePlugin::configure()} wires, checked directly through {@see PluginTester} — the behaviour
+ * suites can only exercise incidentally at suite bootstrap, where it is attributed to no test.
+ */
+#[Test]
+#[Covers(DoublePlugin::class)]
+final class DoublePluginTest
+{
+    public function registersOnlyTheDoubleInterceptor(): void
+    {
+        PluginTester::for(new DoublePlugin())
+            ->addsInterceptor(DoubleInterceptor::class)
+            ->addsInterceptors(1)
+            ->addsListeners(0);
+    }
+}

--- a/bridge/double/tests/suites.php
+++ b/bridge/double/tests/suites.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\Plugin\SuitePlugins;
+use Testo\Application\Config\SuiteConfig;
+use Testo\Bridge\Double\DoublePlugin;
+
+return [
+    new SuiteConfig(
+        name: 'Bridge/Double/Acceptance',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Acceptance'],
+        ),
+        plugins: SuitePlugins::with(new DoublePlugin()),
+    ),
+    new SuiteConfig(
+        name: 'Bridge/Double/Self',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Self'],
+        ),
+        plugins: SuitePlugins::with(new DoublePlugin()),
+    ),
+    // The Feature suite drives Double only through the TestRunner harness (which loads
+    // DoublePlugin itself via #[TestingSuite]), so it runs with the default plugin set.
+    new SuiteConfig(
+        name: 'Bridge/Double/Feature',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Feature'],
+        ),
+    ),
+];

--- a/bridge/double/tests/suites.php
+++ b/bridge/double/tests/suites.php
@@ -27,8 +27,7 @@ return [
         ),
         plugins: SuitePlugins::with(new DoublePlugin()),
     ),
-    // The Feature suite drives Double only through the TestRunner harness (which loads
-    // DoublePlugin itself via #[TestingSuite]), so it runs with the default plugin set.
+    # No DoublePlugin here: the Feature tests load it themselves via #[TestingSuite].
     new SuiteConfig(
         name: 'Bridge/Double/Feature',
         location: new FinderConfig(

--- a/bridge/double/tests/suites.php
+++ b/bridge/double/tests/suites.php
@@ -34,4 +34,10 @@ return [
             include: [__DIR__ . '/Feature'],
         ),
     ),
+    new SuiteConfig(
+        name: 'Bridge/Double/Unit',
+        location: new FinderConfig(
+            include: [__DIR__ . '/Unit'],
+        ),
+    ),
 ];

--- a/bridge/double/tests/suites.php
+++ b/bridge/double/tests/suites.php
@@ -7,6 +7,11 @@ use Testo\Application\Config\Plugin\SuitePlugins;
 use Testo\Application\Config\SuiteConfig;
 use Testo\Bridge\Double\DoublePlugin;
 
+# Double requires PHP 8.3+, above Testo's 8.2 floor. On 8.2 the bridge sits out.
+if (PHP_VERSION_ID < 80300) {
+    return [];
+}
+
 return [
     new SuiteConfig(
         name: 'Bridge/Double/Acceptance',

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
         "llm/skills": "^1.3",
         "roxblnfk/unpoly": "1.8.2",
         "testo/bridge-infection": "^0.1.8",
-        "testo/bridge-mockery": "^0.1.2",
         "testo/facade": "^0.1.1"
     },
     "suggest": {
@@ -83,6 +82,7 @@
         "psr-4": {
             "Internal\\Fiber\\Tests\\": "internal/fiber/tests/",
             "Testo\\Bridge\\Double\\": "bridge/double/src",
+            "Testo\\Bridge\\Mockery\\": "bridge/mockery/src",
             "Testo\\Bridge\\Rector\\": "bridge/rector/src",
             "Testo\\Bridge\\Revolt\\": "bridge/revolt/src",
             "Testo\\Bridge\\VCR\\": "bridge/vcr/src",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "php-vcr/php-vcr": "^1.6",
         "roxblnfk/unpoly": "1.8.2",
         "rector/rector": "^2.6.4",
+        "testo/bridge-double": "^0.1.0",
         "testo/bridge-infection": "^0.1.8",
         "testo/bridge-mockery": "^0.1.2",
         "testo/bridge-rector": "^0.2.5",
@@ -68,6 +69,7 @@
         "testo/facade": "^0.1.1"
     },
     "suggest": {
+        "testo/bridge-double": "Auto-verifies Double mocks, stubs and spies after every test — fiber-safe, no manual verify() calls.",
         "testo/bridge-infection": "Provides integration with Infection PHP mutation testing framework.",
         "testo/bridge-mockery": "Provides integration with the Mockery mocking framework.",
         "llm/skills": "Ship Testo's bundled AI-agent skills into your project's skills directory automatically."
@@ -91,6 +93,7 @@
             "Tests\\Assert\\": "plugin/assert/tests/",
             "Tests\\Fiber\\": "plugin/fiber/tests/",
             "Tests\\Bench\\": "plugin/bench/tests/",
+            "Tests\\Bridge\\Double\\": "bridge/double/tests/",
             "Tests\\Bridge\\Mockery\\": "bridge/mockery/tests/",
             "Tests\\Bridge\\Rector\\": "bridge/rector/tests/",
             "Tests\\Bridge\\Revolt\\": "bridge/revolt/tests/",
@@ -139,6 +142,7 @@
             "options": {
                 "symlink": true,
                 "versions": {
+                    "testo/bridge-double": "0.1.x-dev",
                     "testo/bridge-infection": "0.1.x-dev",
                     "testo/bridge-mockery": "0.1.x-dev",
                     "testo/bridge-rector": "0.2.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "roxblnfk/unpoly": "1.8.2",
         "testo/bridge-infection": "^0.1.8",
         "testo/bridge-mockery": "^0.1.2",
-        "testo/bridge-revolt": "^0.1.2",
         "testo/facade": "^0.1.1"
     },
     "suggest": {
@@ -85,6 +84,7 @@
             "Internal\\Fiber\\Tests\\": "internal/fiber/tests/",
             "Testo\\Bridge\\Double\\": "bridge/double/src",
             "Testo\\Bridge\\Rector\\": "bridge/rector/src",
+            "Testo\\Bridge\\Revolt\\": "bridge/revolt/src",
             "Testo\\Bridge\\VCR\\": "bridge/vcr/src",
             "Tests\\PhpUnit\\": "tests/PhpUnit/",
             "Tests\\": "tests/",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "php-vcr/php-vcr": "^1.6",
         "roxblnfk/unpoly": "1.8.2",
         "rector/rector": "^2.6.4",
-        "testo/bridge-double": "^0.1.0",
         "testo/bridge-infection": "^0.1.8",
         "testo/bridge-mockery": "^0.1.2",
         "testo/bridge-rector": "^0.2.5",
@@ -88,6 +87,7 @@
     "autoload-dev": {
         "psr-4": {
             "Internal\\Fiber\\Tests\\": "internal/fiber/tests/",
+            "Testo\\Bridge\\Double\\": "bridge/double/src",
             "Tests\\PhpUnit\\": "tests/PhpUnit/",
             "Tests\\": "tests/",
             "Tests\\Assert\\": "plugin/assert/tests/",

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,8 @@
         "buggregator/trap": "^1.10",
         "llm/skills": "^1.3",
         "roxblnfk/unpoly": "1.8.2",
-        "rector/rector": "^2.6.4",
         "testo/bridge-infection": "^0.1.8",
         "testo/bridge-mockery": "^0.1.2",
-        "testo/bridge-rector": "^0.2.5",
         "testo/bridge-revolt": "^0.1.2",
         "testo/facade": "^0.1.1"
     },
@@ -86,6 +84,7 @@
         "psr-4": {
             "Internal\\Fiber\\Tests\\": "internal/fiber/tests/",
             "Testo\\Bridge\\Double\\": "bridge/double/src",
+            "Testo\\Bridge\\Rector\\": "bridge/rector/src",
             "Testo\\Bridge\\VCR\\": "bridge/vcr/src",
             "Tests\\PhpUnit\\": "tests/PhpUnit/",
             "Tests\\": "tests/",

--- a/composer.json
+++ b/composer.json
@@ -57,14 +57,12 @@
         "bamarni/composer-bin-plugin": "^1.8",
         "buggregator/trap": "^1.10",
         "llm/skills": "^1.3",
-        "php-vcr/php-vcr": "^1.6",
         "roxblnfk/unpoly": "1.8.2",
         "rector/rector": "^2.6.4",
         "testo/bridge-infection": "^0.1.8",
         "testo/bridge-mockery": "^0.1.2",
         "testo/bridge-rector": "^0.2.5",
         "testo/bridge-revolt": "^0.1.2",
-        "testo/bridge-vcr": "^0.1.1",
         "testo/facade": "^0.1.1"
     },
     "suggest": {
@@ -88,6 +86,7 @@
         "psr-4": {
             "Internal\\Fiber\\Tests\\": "internal/fiber/tests/",
             "Testo\\Bridge\\Double\\": "bridge/double/src",
+            "Testo\\Bridge\\VCR\\": "bridge/vcr/src",
             "Tests\\PhpUnit\\": "tests/PhpUnit/",
             "Tests\\": "tests/",
             "Tests\\Assert\\": "plugin/assert/tests/",
@@ -110,7 +109,8 @@
             "Tests\\Test\\": "plugin/test/tests/"
         },
         "files": [
-            "tests/Fixture/functions.php"
+            "tests/Fixture/functions.php",
+            "bridge/vcr/VCR.php"
         ]
     },
     "repositories": [

--- a/core/Testing/Helper/PluginTester.php
+++ b/core/Testing/Helper/PluginTester.php
@@ -6,6 +6,7 @@ namespace Testo\Testing\Helper;
 
 use Internal\Container\Container;
 use Testo\Assert;
+use Testo\Common\Attribute\AssertMethod;
 use Testo\Common\EventListenerCollector;
 use Testo\Common\PluginConfigurator;
 use Testo\Pipeline\Interceptor;
@@ -69,6 +70,7 @@ final readonly class PluginTester
      *
      * @param class-string<Interceptor> $interceptor
      */
+    #[AssertMethod]
     public function addsInterceptor(string $interceptor): self
     {
         $found = false;
@@ -91,6 +93,7 @@ final readonly class PluginTester
     /**
      * Assert the plugin added exactly this many interceptors.
      */
+    #[AssertMethod]
     public function addsInterceptors(int $count): self
     {
         Assert::count($this->interceptors->interceptors, $count);
@@ -103,6 +106,7 @@ final readonly class PluginTester
      *
      * @param class-string $eventName
      */
+    #[AssertMethod]
     public function addsListener(string $eventName): self
     {
         $found = false;
@@ -125,6 +129,7 @@ final readonly class PluginTester
     /**
      * Assert the plugin added exactly this many listeners.
      */
+    #[AssertMethod]
     public function addsListeners(int $count): self
     {
         Assert::count($this->listeners->listeners, $count);
@@ -137,6 +142,7 @@ final readonly class PluginTester
      *
      * @param class-string $id
      */
+    #[AssertMethod]
     public function binds(string $id): self
     {
         Assert::contains(\array_column($this->container->bindings, 'id'), $id, \sprintf(
@@ -152,6 +158,7 @@ final readonly class PluginTester
      *
      * @param class-string $id
      */
+    #[AssertMethod]
     public function registers(string $id): self
     {
         Assert::contains(\array_column($this->container->registrations, 'id'), $id, \sprintf(

--- a/core/Testing/Helper/PluginTester.php
+++ b/core/Testing/Helper/PluginTester.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Testing\Helper;
+
+use Internal\Container\Container;
+use Testo\Assert;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Pipeline\Interceptor;
+use Testo\Pipeline\InterceptorCollector;
+use Testo\Testing\Internal\Collector\RecordingEventListenerCollector;
+use Testo\Testing\Internal\Collector\RecordingInterceptorCollector;
+use Testo\Testing\Internal\Mock\MockContainer;
+
+/**
+ * Drives a {@see PluginConfigurator} through its {@see PluginConfigurator::configure()} against recording
+ * collectors and a {@see MockContainer}, then exposes fluent assertions over what it registered.
+ *
+ * ```php
+ * PluginTester::for(new MyPlugin())
+ *     ->addsInterceptor(MyInterceptor::class)
+ *     ->addsListener(SessionFinished::class)
+ *     ->binds(SomeService::class);
+ * ```
+ *
+ * Every assertion returns `$this` and reports through the {@see Assert} facade, so a plugin test needs no
+ * assertions of its own. For checks the fluent methods don't cover, read the raw records via
+ * {@see self::interceptors()}, {@see self::listeners()}, {@see self::bindings()} and {@see self::container()}.
+ *
+ * `configure()` never runs the interceptors or listeners it captures, so coverage is not attributed on its
+ * own. Declare `#[Covers]` on the test for the plugin and the code it wires (its interceptors, listeners,
+ * bound services) so those classes are credited.
+ *
+ * @internal
+ * @psalm-internal Testo
+ */
+final readonly class PluginTester
+{
+    private function __construct(
+        private RecordingInterceptorCollector $interceptors,
+        private RecordingEventListenerCollector $listeners,
+        private MockContainer $container,
+    ) {}
+
+    /**
+     * Configure the plugin and capture what it registers.
+     *
+     * @param Container|null $inner Backing container for services the plugin resolves beyond the collectors
+     *        (e.g. a CLI input, an event dispatcher). Defaults to a fresh autowiring container.
+     */
+    public static function for(PluginConfigurator $plugin, ?Container $inner = null): self
+    {
+        $interceptors = new RecordingInterceptorCollector();
+        $listeners = new RecordingEventListenerCollector();
+        $container = new MockContainer($inner);
+        $container->preset($interceptors, InterceptorCollector::class);
+        $container->preset($listeners, EventListenerCollector::class);
+
+        $plugin->configure($container);
+
+        return new self($interceptors, $listeners, $container);
+    }
+
+    /**
+     * Assert the plugin added an interceptor of the given class, whether it passed an instance or a
+     * class-string.
+     *
+     * @param class-string<Interceptor> $interceptor
+     */
+    public function addsInterceptor(string $interceptor): self
+    {
+        $found = false;
+        foreach ($this->interceptorClasses() as $class) {
+            if ($class === $interceptor || \is_a($class, $interceptor, true)) {
+                $found = true;
+                break;
+            }
+        }
+
+        Assert::true($found, \sprintf(
+            'Plugin did not add interceptor %s. Added: %s',
+            $interceptor,
+            $this->describe($this->interceptorClasses()),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert the plugin added exactly this many interceptors.
+     */
+    public function addsInterceptors(int $count): self
+    {
+        Assert::count($this->interceptors->interceptors, $count);
+
+        return $this;
+    }
+
+    /**
+     * Assert the plugin registered a listener for the given event class.
+     *
+     * @param class-string $eventName
+     */
+    public function addsListener(string $eventName): self
+    {
+        $found = false;
+        foreach ($this->listeners->listeners as $listener) {
+            if ($listener['event'] === $eventName) {
+                $found = true;
+                break;
+            }
+        }
+
+        Assert::true($found, \sprintf(
+            'Plugin did not add a listener for %s. Listened: %s',
+            $eventName,
+            $this->describe(\array_column($this->listeners->listeners, 'event')),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert the plugin added exactly this many listeners.
+     */
+    public function addsListeners(int $count): self
+    {
+        Assert::count($this->listeners->listeners, $count);
+
+        return $this;
+    }
+
+    /**
+     * Assert the plugin declared a binding for the given service id via {@see Container::bind()}.
+     *
+     * @param class-string $id
+     */
+    public function binds(string $id): self
+    {
+        Assert::contains(\array_column($this->container->bindings, 'id'), $id, \sprintf(
+            'Plugin did not bind %s.',
+            $id,
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert the plugin registered a service instance for the given id via {@see Container::set()}.
+     *
+     * @param class-string $id
+     */
+    public function registers(string $id): self
+    {
+        Assert::contains(\array_column($this->container->registrations, 'id'), $id, \sprintf(
+            'Plugin did not register a service for %s.',
+            $id,
+        ));
+
+        return $this;
+    }
+
+    /**
+     * The interceptors the plugin added, each as the instance or class-string it passed.
+     *
+     * @return list<Interceptor|class-string<Interceptor>>
+     */
+    public function interceptors(): array
+    {
+        return $this->interceptors->interceptors;
+    }
+
+    /**
+     * The listeners the plugin registered.
+     *
+     * @return list<array{event: class-string, callback: callable, priority: int}>
+     */
+    public function listeners(): array
+    {
+        return $this->listeners->listeners;
+    }
+
+    /**
+     * The bindings the plugin declared via {@see Container::bind()}.
+     *
+     * @return list<array{id: class-string, binding: \Closure|class-string|array<string, mixed>|null}>
+     */
+    public function bindings(): array
+    {
+        return $this->container->bindings;
+    }
+
+    public function container(): MockContainer
+    {
+        return $this->container;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function interceptorClasses(): array
+    {
+        return \array_map(
+            static fn(Interceptor|string $i): string => \is_object($i) ? $i::class : $i,
+            $this->interceptors->interceptors,
+        );
+    }
+
+    /**
+     * @param list<string> $items
+     */
+    private function describe(array $items): string
+    {
+        return $items === [] ? '(none)' : \implode(', ', $items);
+    }
+}

--- a/core/Testing/Internal/Collector/RecordingEventListenerCollector.php
+++ b/core/Testing/Internal/Collector/RecordingEventListenerCollector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Testing\Internal\Collector;
+
+use Testo\Common\EventListenerCollector;
+
+/**
+ * An {@see EventListenerCollector} that records the listeners a plugin registers instead of dispatching to
+ * them. Each entry keeps the event class, the callback and the priority the plugin passed.
+ *
+ * @internal
+ * @psalm-internal Testo\Testing
+ */
+final class RecordingEventListenerCollector implements EventListenerCollector
+{
+    /** @var list<array{event: class-string, callback: callable, priority: int}> */
+    public array $listeners = [];
+
+    #[\Override]
+    public function addListener(string $eventName, callable $callback, int $priority = 0): void
+    {
+        $this->listeners[] = ['event' => $eventName, 'callback' => $callback, 'priority' => $priority];
+    }
+}

--- a/core/Testing/Internal/Collector/RecordingInterceptorCollector.php
+++ b/core/Testing/Internal/Collector/RecordingInterceptorCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Testing\Internal\Collector;
+
+use Testo\Pipeline\Interceptor;
+use Testo\Pipeline\InterceptorCollector;
+
+/**
+ * An {@see InterceptorCollector} that records what a plugin adds instead of wiring it into a pipeline.
+ *
+ * Entries keep the exact argument the plugin passed — an instance when it built one, a class-string when
+ * it left construction to the container — so a test can assert on either form.
+ *
+ * @internal
+ * @psalm-internal Testo\Testing
+ */
+final class RecordingInterceptorCollector implements InterceptorCollector
+{
+    /** @var list<Interceptor|class-string<Interceptor>> */
+    public array $interceptors = [];
+
+    #[\Override]
+    public function addInterceptor(Interceptor|string $interceptor): void
+    {
+        $this->interceptors[] = $interceptor;
+    }
+}

--- a/core/Testing/Internal/Mock/MockContainer.php
+++ b/core/Testing/Internal/Mock/MockContainer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Testing\Internal\Mock;
+
+use Internal\Container\Container;
+use Internal\Container\ObjectContainer;
+
+/**
+ * A {@see Container} that records every {@see self::set()} and {@see self::bind()} a plugin makes so a test
+ * can assert on the bindings it declared. Resolution is delegated to a real backing container, so a plugin
+ * that reads services back through {@see self::get()} still works.
+ *
+ * Use {@see self::preset()} to seed a service the plugin will resolve (a recording collector, a stub input)
+ * without it counting as one of the plugin's own registrations.
+ *
+ * @internal
+ * @psalm-internal Testo\Testing
+ */
+final class MockContainer implements Container
+{
+    /** @var list<array{service: object, id: class-string, destroy: bool}> */
+    public array $registrations = [];
+
+    /** @var list<array{id: class-string, binding: \Closure|class-string|array<string, mixed>|null}> */
+    public array $bindings = [];
+
+    private readonly Container $inner;
+
+    public function __construct(?Container $inner = null)
+    {
+        $this->inner = $inner ?? new ObjectContainer();
+    }
+
+    /**
+     * Seed a service the plugin will resolve, bypassing the recording so it is not mistaken for one of the
+     * plugin's own registrations.
+     *
+     * @param class-string|null $id Defaults to the service's own class.
+     */
+    public function preset(object $service, ?string $id = null): void
+    {
+        $this->inner->set($service, $id);
+    }
+
+    #[\Override]
+    public function get(string $id, array $arguments = []): object
+    {
+        return $this->inner->get($id, $arguments);
+    }
+
+    #[\Override]
+    public function has(string $id): bool
+    {
+        return $this->inner->has($id);
+    }
+
+    #[\Override]
+    public function set(object $service, ?string $id = null, bool $destroy = false): void
+    {
+        $this->registrations[] = ['service' => $service, 'id' => $id ?? $service::class, 'destroy' => $destroy];
+        $this->inner->set($service, $id, $destroy);
+    }
+
+    #[\Override]
+    public function make(string $class, array $arguments = []): object
+    {
+        return $this->inner->make($class, $arguments);
+    }
+
+    #[\Override]
+    public function bind(string $id, \Closure|string|array|null $binding = null): void
+    {
+        $this->bindings[] = ['id' => $id, 'binding' => $binding];
+        $this->inner->bind($id, $binding);
+    }
+
+    #[\Override]
+    public function scope(\Closure $scope): mixed
+    {
+        return $this->inner->scope($scope);
+    }
+
+    #[\Override]
+    public function destroy(): void
+    {
+        $this->inner->destroy();
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,7 @@
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="tools/phpunit/vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory="runtime/.phpunit.cache"
          executionOrder="depends"
          failOnRisky="false"

--- a/testo.php
+++ b/testo.php
@@ -7,8 +7,7 @@ use Testo\Application\Config\FinderConfig;
 use Testo\Application\Config\SuiteConfig;
 use Testo\Testing\InjectPlugin;
 
-# Load the root autoloader plus the isolated bin vendors that hold bridge runtime deps kept out
-# of the root install. Shared with the PHPUnit mirror (phpunit.xml) so both runners see the bridges.
+# Bridge runtime deps aren't in the root install; the bootstrap loads them from the isolated bin vendors.
 require __DIR__ . '/tests/bootstrap.php';
 
 return new ApplicationConfig(

--- a/testo.php
+++ b/testo.php
@@ -8,10 +8,10 @@ use Testo\Application\Config\SuiteConfig;
 use Testo\Testing\InjectPlugin;
 
 # Some bridges keep their runtime deps out of the root install: double needs a higher PHP floor
-# than Testo's. That dep lives in an isolated bamarni-bin vendor under tools/. Register the
-# autoloader here so the self-hosted run can load the bridge code; the bridge's suites.php still
-# gates itself on the platform it needs.
-foreach (['double'] as $binNamespace) {
+# than Testo's, vcr drags heavy transitive deps. Those deps live in isolated bamarni-bin vendors
+# under tools/. Register the autoloaders here so the self-hosted run can load the bridge code;
+# each bridge's suites.php still gates itself on the platform it needs.
+foreach (['double', 'vcr'] as $binNamespace) {
     $autoload = __DIR__ . "/tools/{$binNamespace}/vendor/autoload.php";
     \is_file($autoload) and require_once $autoload;
 }

--- a/testo.php
+++ b/testo.php
@@ -7,6 +7,15 @@ use Testo\Application\Config\FinderConfig;
 use Testo\Application\Config\SuiteConfig;
 use Testo\Testing\InjectPlugin;
 
+# Some bridges keep their runtime deps out of the root install: double needs a higher PHP floor
+# than Testo's. That dep lives in an isolated bamarni-bin vendor under tools/. Register the
+# autoloader here so the self-hosted run can load the bridge code; the bridge's suites.php still
+# gates itself on the platform it needs.
+foreach (['double'] as $binNamespace) {
+    $autoload = __DIR__ . "/tools/{$binNamespace}/vendor/autoload.php";
+    \is_file($autoload) and require_once $autoload;
+}
+
 return new ApplicationConfig(
     src: new FinderConfig(
         ['core', 'plugin', 'bridge'],

--- a/testo.php
+++ b/testo.php
@@ -7,14 +7,9 @@ use Testo\Application\Config\FinderConfig;
 use Testo\Application\Config\SuiteConfig;
 use Testo\Testing\InjectPlugin;
 
-# Some bridges keep their runtime deps out of the root install: double needs a higher PHP floor
-# than Testo's, vcr and rector drag heavy transitive deps. Those deps live in isolated bamarni-bin
-# vendors under tools/. Register the autoloaders here so the self-hosted run can load the bridge
-# code; each bridge's suites.php still gates itself on the platform it needs.
-foreach (['double', 'vcr', 'rector'] as $binNamespace) {
-    $autoload = __DIR__ . "/tools/{$binNamespace}/vendor/autoload.php";
-    \is_file($autoload) and require_once $autoload;
-}
+# Load the root autoloader plus the isolated bin vendors that hold bridge runtime deps kept out
+# of the root install. Shared with the PHPUnit mirror (phpunit.xml) so both runners see the bridges.
+require __DIR__ . '/tests/bootstrap.php';
 
 return new ApplicationConfig(
     src: new FinderConfig(

--- a/testo.php
+++ b/testo.php
@@ -11,6 +11,7 @@ return new ApplicationConfig(
     src: new FinderConfig(
         ['core', 'plugin', 'bridge'],
         [
+            'bridge/double/tests',
             'bridge/mockery/tests',
             'bridge/rector/tests',
             'bridge/revolt/tests',
@@ -50,6 +51,7 @@ return new ApplicationConfig(
             ),
         ],
         require 'internal/fiber/tests/suites.php',
+        require 'bridge/double/tests/suites.php',
         require 'bridge/mockery/tests/suites.php',
         require 'bridge/rector/tests/suites.php',
         require 'bridge/revolt/tests/suites.php',

--- a/testo.php
+++ b/testo.php
@@ -8,10 +8,10 @@ use Testo\Application\Config\SuiteConfig;
 use Testo\Testing\InjectPlugin;
 
 # Some bridges keep their runtime deps out of the root install: double needs a higher PHP floor
-# than Testo's, vcr drags heavy transitive deps. Those deps live in isolated bamarni-bin vendors
-# under tools/. Register the autoloaders here so the self-hosted run can load the bridge code;
-# each bridge's suites.php still gates itself on the platform it needs.
-foreach (['double', 'vcr'] as $binNamespace) {
+# than Testo's, vcr and rector drag heavy transitive deps. Those deps live in isolated bamarni-bin
+# vendors under tools/. Register the autoloaders here so the self-hosted run can load the bridge
+# code; each bridge's suites.php still gates itself on the platform it needs.
+foreach (['double', 'vcr', 'rector'] as $binNamespace) {
     $autoload = __DIR__ . "/tools/{$binNamespace}/vendor/autoload.php";
     \is_file($autoload) and require_once $autoload;
 }

--- a/tests/Core/Testing/Stub/Plugin/AnotherStubInterceptor.php
+++ b/tests/Core/Testing/Stub/Plugin/AnotherStubInterceptor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+use Testo\Pipeline\Interceptor;
+
+final class AnotherStubInterceptor implements Interceptor {}

--- a/tests/Core/Testing/Stub/Plugin/DestroyableStubService.php
+++ b/tests/Core/Testing/Stub/Plugin/DestroyableStubService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+use Internal\Destroy\Destroyable;
+
+/**
+ * Flips {@see self::$destroyed} when the container tears it down — lets a test observe that
+ * {@see \Testo\Testing\Internal\Mock\MockContainer::destroy()} reaches the services it manages.
+ */
+final class DestroyableStubService implements Destroyable
+{
+    public bool $destroyed = false;
+
+    #[\Override]
+    public function destroy(): void
+    {
+        $this->destroyed = true;
+    }
+}

--- a/tests/Core/Testing/Stub/Plugin/RecordingStubPlugin.php
+++ b/tests/Core/Testing/Stub/Plugin/RecordingStubPlugin.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+use Internal\Container\Container;
+use Testo\Common\EventListenerCollector;
+use Testo\Common\PluginConfigurator;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Pipeline\InterceptorCollector;
+
+/**
+ * Exercises every registration seam a plugin can touch, so {@see \Testo\Testing\Helper\PluginTester} has
+ * something to capture: an interceptor added as an instance and one added as a class-string, a listener, a
+ * binding and a service registration.
+ */
+final class RecordingStubPlugin implements PluginConfigurator
+{
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $interceptors = $container->get(InterceptorCollector::class);
+        $interceptors->addInterceptor(new StubInterceptor());
+        $interceptors->addInterceptor(AnotherStubInterceptor::class);
+
+        $container->get(EventListenerCollector::class)
+            ->addListener(SessionFinished::class, static fn(): null => null);
+
+        $container->bind(StubService::class, StubService::class);
+        $container->set(new StubService());
+    }
+}

--- a/tests/Core/Testing/Stub/Plugin/StubInterceptor.php
+++ b/tests/Core/Testing/Stub/Plugin/StubInterceptor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+use Testo\Pipeline\Interceptor;
+
+final class StubInterceptor implements Interceptor {}

--- a/tests/Core/Testing/Stub/Plugin/StubService.php
+++ b/tests/Core/Testing/Stub/Plugin/StubService.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+final class StubService {}

--- a/tests/Core/Testing/Stub/Plugin/UnusedStubInterceptor.php
+++ b/tests/Core/Testing/Stub/Plugin/UnusedStubInterceptor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub\Plugin;
+
+use Testo\Pipeline\Interceptor;
+
+/**
+ * An interceptor the stub plugin never adds — the target for asserting that a missing-interceptor check
+ * fails.
+ */
+final class UnusedStubInterceptor implements Interceptor {}

--- a/tests/Core/Testing/Unit/MockContainerTest.php
+++ b/tests/Core/Testing/Unit/MockContainerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Unit;
+
+use Internal\Container\Container;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Test;
+use Testo\Testing\Internal\Mock\MockContainer;
+use Tests\Core\Testing\Stub\Plugin\DestroyableStubService;
+use Tests\Core\Testing\Stub\Plugin\StubService;
+
+#[Test]
+#[Covers(MockContainer::class)]
+final class MockContainerTest
+{
+    public function recordsRegistrationsAndStillResolvesThem(): void
+    {
+        $container = new MockContainer();
+        $service = new StubService();
+
+        $container->set($service);
+
+        Assert::same($container->registrations[0]['id'], StubService::class);
+        Assert::same($container->get(StubService::class), $service);
+    }
+
+    public function recordsBindingsAndReportsThemAsAvailable(): void
+    {
+        $container = new MockContainer();
+
+        $container->bind(StubService::class, StubService::class);
+
+        Assert::same($container->bindings[0]['id'], StubService::class);
+        Assert::true($container->has(StubService::class));
+    }
+
+    public function presetSeedsAServiceWithoutRecordingIt(): void
+    {
+        $container = new MockContainer();
+        $service = new StubService();
+
+        $container->preset($service);
+
+        Assert::same($container->get(StubService::class), $service);
+        Assert::count($container->registrations, 0);
+    }
+
+    public function makeBuildsAFreshInstanceWithoutStoringIt(): void
+    {
+        $container = new MockContainer();
+
+        $made = $container->make(StubService::class);
+
+        Assert::instanceOf($made, StubService::class);
+        Assert::false($container->has(StubService::class));
+    }
+
+    public function scopeRunsTheClosureAndReturnsItsValue(): void
+    {
+        $container = new MockContainer();
+
+        $result = $container->scope(static fn(Container $c): int => $c->has(StubService::class) ? 1 : 42);
+
+        Assert::same($result, 42);
+    }
+
+    public function destroyReachesManagedServices(): void
+    {
+        $container = new MockContainer();
+        $service = new DestroyableStubService();
+        $container->set($service, destroy: true);
+
+        $container->destroy();
+
+        Assert::true($service->destroyed);
+    }
+}

--- a/tests/Core/Testing/Unit/PluginTesterTest.php
+++ b/tests/Core/Testing/Unit/PluginTesterTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Unit;
+
+use Testo\Assert;
+use Testo\Assert\Internal\StaticState;
+use Testo\Assert\State\Assertion\AssertionException;
+use Testo\Codecov\Covers;
+use Testo\Event\Framework\SessionFinished;
+use Testo\Test;
+use Testo\Testing\Helper\PluginTester;
+use Testo\Testing\Internal\Collector\RecordingEventListenerCollector;
+use Testo\Testing\Internal\Collector\RecordingInterceptorCollector;
+use Testo\Testing\Internal\Mock\MockContainer;
+use Tests\Core\Testing\Stub\Plugin\AnotherStubInterceptor;
+use Tests\Core\Testing\Stub\Plugin\RecordingStubPlugin;
+use Tests\Core\Testing\Stub\Plugin\StubInterceptor;
+use Tests\Core\Testing\Stub\Plugin\StubService;
+use Tests\Core\Testing\Stub\Plugin\UnusedStubInterceptor;
+
+#[Test]
+#[Covers(PluginTester::class)]
+#[Covers(MockContainer::class)]
+#[Covers(RecordingInterceptorCollector::class)]
+#[Covers(RecordingEventListenerCollector::class)]
+final class PluginTesterTest
+{
+    public function capturesInterceptorAddedAsInstance(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->addsInterceptor(StubInterceptor::class);
+    }
+
+    public function capturesInterceptorAddedAsClassString(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->addsInterceptor(AnotherStubInterceptor::class);
+    }
+
+    public function countsAllAddedInterceptors(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->addsInterceptors(2);
+    }
+
+    public function capturesListenerByEvent(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->addsListener(SessionFinished::class)
+            ->addsListeners(1);
+    }
+
+    public function capturesBinding(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->binds(StubService::class);
+    }
+
+    public function capturesServiceRegistration(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->registers(StubService::class);
+    }
+
+    public function rawAccessorsExposeEveryRecord(): void
+    {
+        $tester = PluginTester::for(new RecordingStubPlugin());
+
+        Assert::count($tester->interceptors(), 2);
+        Assert::count($tester->listeners(), 1);
+        Assert::count($tester->bindings(), 1);
+        Assert::same($tester->listeners()[0]['event'], SessionFinished::class);
+    }
+
+    public function fluentChecksChainOnOneRun(): void
+    {
+        PluginTester::for(new RecordingStubPlugin())
+            ->addsInterceptor(StubInterceptor::class)
+            ->addsInterceptor(AnotherStubInterceptor::class)
+            ->addsListener(SessionFinished::class)
+            ->binds(StubService::class)
+            ->registers(StubService::class);
+    }
+
+    public function exposesTheMockContainerForBindingChecks(): void
+    {
+        $container = PluginTester::for(new RecordingStubPlugin())->container();
+
+        Assert::same($container->bindings[0]['id'], StubService::class);
+    }
+
+    public function missingInterceptorFailsTheAssertion(): void
+    {
+        // The failing check throws AND records a failed expectation on the active state; swap it out so the
+        // deliberate failure neither pollutes this test's history nor fails it, then restore.
+        $restore = StaticState::swap(null);
+        $threw = false;
+        try {
+            PluginTester::for(new RecordingStubPlugin())
+                ->addsInterceptor(UnusedStubInterceptor::class);
+        } catch (AssertionException) {
+            $threw = true;
+        } finally {
+            StaticState::swap($restore);
+        }
+
+        Assert::true($threw, 'addsInterceptor should fail when the interceptor was never added');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared autoload bootstrap for every runner over Testo's own suite: the Testo CLI (testo.php),
+ * the generated PHPUnit mirror (phpunit.xml) and mutation testing on top of either.
+ *
+ * It loads the root autoloader, then the isolated bamarni-bin vendors under tools/ that hold the
+ * bridge runtime deps kept out of the root install — a higher PHP floor (double) or heavy/foreign
+ * transitive deps (vcr, mockery, revolt, rector). The is_file() guard keeps a run working when a
+ * bin namespace was not installed (double on PHP 8.2, a job that skipped it); the bridge's own
+ * suites.php still gates itself on the platform it needs.
+ *
+ * Only bridge vendors are listed. The standalone dev tools (psalm, phpunit, infection, code-style)
+ * also live under tools/, but their nikic/symfony deps differ by version and would clash if loaded
+ * into the same process as the tests.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+foreach (['double', 'vcr', 'mockery', 'revolt', 'rector'] as $binNamespace) {
+    $autoload = __DIR__ . "/../tools/{$binNamespace}/vendor/autoload.php";
+    \is_file($autoload) and require_once $autoload;
+}

--- a/tools/double/composer.json
+++ b/tools/double/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "jasonmccreary/double": "dev-master"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "platform-check": false
+    }
+}

--- a/tools/mockery/composer.json
+++ b/tools/mockery/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "mockery/mockery": "^1.6"
+    },
+    "config": {
+        "platform-check": false
+    }
+}

--- a/tools/rector/composer.json
+++ b/tools/rector/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "rector/rector": "^2.6.4"
+    },
+    "config": {
+        "platform-check": false
+    }
+}

--- a/tools/revolt/composer.json
+++ b/tools/revolt/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "revolt/event-loop": "^1.0"
+    },
+    "config": {
+        "platform-check": false
+    }
+}

--- a/tools/vcr/composer.json
+++ b/tools/vcr/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php-vcr/php-vcr": "^1.6"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "platform-check": false
+    }
+}


### PR DESCRIPTION
## 🔍 What was changed

- New `testo/bridge-double` package (`bridge/double/`) integrating [jasonmccreary/double](https://github.com/jasonmccreary/double) — a test-double library (mocks, stubs, spies) — mirroring the Mockery bridge.
- `DoublePlugin` registers an innermost `DoubleInterceptor` that arms `Double::armAutoVerify()` before each test and runs `Double::verifyAll()` after, so unmet `expects()`/`received()` assertions fail the test with no per-test `verify()` boilerplate. Verified expectations are reported to the Assert plugin so a double-only test isn't flagged as making no assertions.
- Fiber-safe by the same technique the Mockery bridge uses for its container: Double's process-global auto-verify state is snapshotted and restored around every suspension, keeping interleaving tests isolated.

### How it works

- Sequential — arm → run → `verifyAll()` in a `finally` (always drains; an unmet expectation turns an otherwise-passing test `Failed`, while an already-failed result is left alone).
- Concurrent — the test runs in a trampoline fiber; on each suspension this test's `$pending`/`$pendingReceived`/`$autoVerifyArmed` are saved and a fresh slate handed to the sibling, then restored on resume.
- Not touched — Double's `$states` WeakMap (double → state) is object-keyed and never shared, so it is left alone.

## Why?

Gives Testo users an alternative test-double library to Mockery, as requested in #296.

## Review notes

- Double exposes no public seam for its pending state, so `Internal\GlobalState` reads and writes three private statics on the `Double` facade by reflection — pinned to `jasonmccreary/double: ^0.6.1`.
- Two items are deferred until Double reaches a stable release (details in #296): Double requires PHP `^8.3` while Testo's CI matrix still includes 8.2 (fix proposed upstream: jasonmccreary/double#9), and the package is intentionally left out of the release infra (release-please config, version manifest, split-publish) for now. It is wired into `composer.json` and the self-test suites only.

## Checklist

- Related to #296
- How was this tested:
  - [x] Unit tests added — Acceptance / Self / Feature suites, 21 tests incl. a Revolt await, a solo fiber, and a RoundRobin interleave that verifies per-test isolation and `Expect::exception` transparency
  - [x] Tested manually — ran the three suites locally on PHP 8.4: 21/21 passed
