### PR TITLE
fix(output): honour --no-ansi and NO_COLOR

### DIFF
--- a/bridge/symfony-console/src/Command/Base.php
+++ b/bridge/symfony-console/src/Command/Base.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Testo\Application\Application;
 use Testo\Core\Value\Verbosity;
+use Testo\Output\Terminal\Renderer\ColorMode;
 use Yiisoft\Injector\Injector;
 
 /**
@@ -85,6 +86,7 @@ abstract class Base extends Command
         $this->container->set($output, OutputInterface::class);
         $this->container->set(new SymfonyStyle($input, $output), StyleInterface::class);
         $this->container->set(self::resolveVerbosity($output), Verbosity::class);
+        $this->container->set(self::resolveColorMode($input), ColorMode::class);
 
         return $this->container->get(Injector::class)->invoke($this) ?? Command::SUCCESS;
     }
@@ -127,5 +129,23 @@ abstract class Base extends Command
             OutputInterface::VERBOSITY_DEBUG => Verbosity::Debug,
             default => Verbosity::Normal,
         };
+    }
+
+    /**
+     * Colors stay on unless they are turned off explicitly — by `--no-ansi` or by the `NO_COLOR`
+     * convention (<https://no-color.org/>). A redirected stdout keeps them: piping into a file or a
+     * pager is not by itself a request for plain text, and a caller who wants plain text has a flag
+     * to say so.
+     *
+     * This deliberately does not go through {@see OutputInterface::isDecorated()}, which folds the
+     * explicit request together with TTY detection and so cannot tell "the user asked for no color"
+     * apart from "stdout is not a terminal".
+     */
+    private static function resolveColorMode(InputInterface $input): ColorMode
+    {
+        $disabled = $input->hasParameterOption('--no-ansi', true)
+            || ($_SERVER['NO_COLOR'] ?? $_ENV['NO_COLOR'] ?? '') !== '';
+
+        return $disabled ? ColorMode::Never : ColorMode::Always;
     }
 }

--- a/core/Output/Teamcity/Teamcity/TeamcityLogger.php
+++ b/core/Output/Teamcity/Teamcity/TeamcityLogger.php
@@ -20,6 +20,7 @@ use Testo\Core\Log\Message;
 use Testo\Core\Value\Status;
 use Testo\Core\Report\ReportInfo;
 use Testo\Output\Rendering\StackTrace;
+use Testo\Output\Terminal\Renderer\Style;
 
 /**
  * TeamCity logger for test reporting using DTO objects.
@@ -77,7 +78,7 @@ final class TeamcityLogger
      */
     public function logEnvironment(): void
     {
-        $this->publish("\033[1m" . Info::NAME . "\033[0m" . self::dim(' v' . Info::version()));
+        $this->publish(Style::bold(Info::NAME) . self::dim(' v' . Info::version()));
 
         $this->publish(Formatter::blockOpened('Environment'));
 
@@ -418,12 +419,14 @@ final class TeamcityLogger
 
     private static function key(string $name): string
     {
-        return "\033[36;1m{$name}:\033[0m ";
+        return Style::areColorsEnabled()
+            ? "\033[36;1m{$name}:\033[0m "
+            : "{$name}: ";
     }
 
     private static function dim(string $text): string
     {
-        return "\033[2m{$text}\033[0m";
+        return Style::dim($text);
     }
 
     /**

--- a/core/Output/Teamcity/TeamcityPlugin.php
+++ b/core/Output/Teamcity/TeamcityPlugin.php
@@ -24,6 +24,8 @@ use Testo\Event\TestCase\TestCaseStarting;
 use Testo\Event\TestSuite\TestSuiteFinished;
 use Testo\Event\TestSuite\TestSuiteStarting;
 use Testo\Output\Teamcity\Teamcity\TeamcityLogger;
+use Testo\Output\Terminal\Renderer\ColorMode;
+use Testo\Output\Terminal\Renderer\Style;
 
 final class TeamcityPlugin implements PluginConfigurator
 {
@@ -58,8 +60,12 @@ final class TeamcityPlugin implements PluginConfigurator
 
     private readonly TeamcityLogger $logger;
 
-    public function __construct()
+    public function __construct(ColorMode $colorMode = ColorMode::Always)
     {
+        // Service messages are parsed by the CI server, but the human-readable lines around them go
+        // through the same styling as the terminal renderer's — so the color decision has to be made
+        // here too, or `--no-ansi` would leave ANSI in a machine-read stream.
+        Style::setColorsEnabled($colorMode->shouldUseColors());
         $this->logger = new TeamcityLogger();
     }
 


### PR DESCRIPTION
# Summary

`--no-ansi` and the `NO_COLOR` convention had no effect: Testo emitted ANSI escape sequences unconditionally, so a redirected run always produced a file full of escape codes and there was no way to ask for plain text.

This makes both work. Colours stay **on by default** — including when stdout is redirected — so nothing changes unless you explicitly ask for plain output.

# Why it didn't work

Two independent causes, and fixing either alone would not have been enough.

## 1. The colour mode was never passed to the renderer

`TerminalPlugin` already takes a `ColorMode` and applies it:

```php
public function __construct(
    private readonly TerminalLogger $logger,
    ColorMode $colorMode = ColorMode::Always,
) {
    Style::setColorsEnabled($colorMode->shouldUseColors());
}
```

But the plugin is built by the container (`Run::__invoke()` resolves it by class name), and nothing ever put a `ColorMode` into the container. The constructor default was therefore the only value that could ever be used, and that default is `Always`.

Two consequences followed from that single gap:

- `ColorMode::Auto` and `ColorMode::Never` were unreachable — dead code. With them, everything `Auto` implements went unused too: `NO_COLOR` detection, `TERM=dumb`, CI-without-TTY, `posix_isatty()`.
- `--ansi|--no-ansi` is listed in `--help` (Symfony Console registers it on every command) while doing nothing. The CLI documented a flag it ignored.

The console bridge already had the mechanism needed to close this — it is how `Verbosity` reaches the renderer:

```php
$this->container->set(self::resolveVerbosity($output), Verbosity::class);
```

`ColorMode` simply had no equivalent line.

## 2. The TeamCity logger bypassed the styling layer

`TeamcityLogger` hardcoded escape sequences instead of going through `Style`:

```php
$this->publish("\033[1m" . Info::NAME . "\033[0m" . self::dim(' v' . Info::version()));

private static function key(string $name): string
{
    return "\033[36;1m{$name}:\033[0m ";
}

private static function dim(string $text): string
{
    return "\033[2m{$text}\033[0m";
}
```

So even once the mode was delivered, `--teamcity` would have kept emitting ANSI — in a stream that a CI server parses.

# What changed

**`bridge/symfony-console/src/Command/Base.php`** — put `ColorMode` into the container next to `Verbosity`:

```php
$this->container->set(self::resolveVerbosity($output), Verbosity::class);
$this->container->set(self::resolveColorMode($input), ColorMode::class);
```

```php
private static function resolveColorMode(InputInterface $input): ColorMode
{
    $disabled = $input->hasParameterOption('--no-ansi', true)
        || ($_SERVER['NO_COLOR'] ?? $_ENV['NO_COLOR'] ?? '') !== '';

    return $disabled ? ColorMode::Never : ColorMode::Always;
}
```

**`core/Output/Teamcity/Teamcity/TeamcityLogger.php`** — the three hardcoded sequences now go through `Style`. Two of them are byte-for-byte substitutions: `Style::bold()` and `Style::dim()` produce exactly `"\033[1m…\033[0m"` and `"\033[2m…\033[0m"`. The third, `\033[36;1m` (cyan + bold), has no matching `Color` case, so the sequence is kept as-is behind a `Style::areColorsEnabled()` check. **With colours enabled the output is unchanged, byte for byte.**

**`core/Output/Teamcity/TeamcityPlugin.php`** — accepts a `ColorMode` and applies it, the way `TerminalPlugin` already does.

`TerminalPlugin` itself needed no change at all — it was already correct.

# Behaviour

Colours are disabled only when explicitly requested. A redirected stdout is not by itself a request for plain text — piping into a file or a pager says nothing about colour preference, and a caller who wants plain text has a flag to say so. This keeps the change strictly additive: **without a flag, nothing changes anywhere.**

Escape sequences in the output of `testo --suite=… > file`:

| Invocation | Before | After |
| --- | --- | --- |
| no flags, stdout redirected | 17 | 17 |
| `--ansi` | 17 | 17 |
| attached to a TTY | 17 | 17 |
| `--teamcity` | 4 | 4 |
| `--no-ansi` | 17 | **0** |
| `NO_COLOR=1` | 17 | **0** |
| `--teamcity --no-ansi` | 4 | **0** |
| `NO_COLOR=` (empty) | 17 | 17 |

The last row follows <https://no-color.org/>: the variable counts as set only when it holds a non-empty value. Symfony Console reads it the same way.

# Design notes

**Why not `OutputInterface::isDecorated()`.** It is the obvious candidate, and it is wrong for this behaviour: Symfony folds the explicit request together with TTY detection into a single boolean, so it cannot tell "the user asked for no colour" apart from "stdout is not a terminal". Using it would have switched the default to *off on redirect*, which is a behaviour change for everyone who redirects and expects colour today. Reading the flag directly keeps the two apart.

**`NO_COLOR` lookup.** Read from `$_SERVER`/`$_ENV`, matching the existing detection in `ColorMode::Auto` rather than introducing a second convention in the same codebase.

**`ColorMode::Auto` stays the road not taken.** It remains available and is now reachable for anyone constructing the plugins directly, but the CLI does not select it — auto-detection is exactly what the "colours by default" decision rejects. The renderer defaults stay `Always`, so embedding Testo without this bridge behaves as before.

# For maintainer judgement

For `--teamcity` the stream is machine-read, and the case for auto-detection there is stronger than the case for "colour unless told otherwise". This PR keeps the behaviour uniform across renderers rather than special-casing one; happy to change it if you would rather TeamCity default to plain.

# Verification

All green locally on PHP 8.4:

| Check | Result |
| --- | --- |
| `composer test:ci` | 1724 tests, 3708 assertions — 1719 passed, 4 risky, 1 flaky |
| `composer rector:ci` | exit 0 |
| `composer psalm:ci` | exit 0 |
| `composer cs:diff` | 0 of 182 files need fixing |

The before/after table above was measured by counting `ESC` bytes in redirected output; the TTY rows were measured under `script(1)` so a real terminal is attached.

# Notes

- No skill updates needed: `--ansi`/`--no-ansi` are Symfony Console flags and are not described in `skills/`.
- No `bridge/rector` counterpart: no user-facing test-authoring surface was added.
- Diff is 3 files, +33/−4.
