### PR TITLE
fix(bench): measure peak memory per iteration instead of an end-to-end delta

### DIFF
--- a/plugin/bench/src/Dto/Snap.php
+++ b/plugin/bench/src/Dto/Snap.php
@@ -13,7 +13,7 @@ final readonly class Snap
         /** @var int<1, max> Number of calls in the iteration. */
         public int $calls,
 
-        /** @var int<0, max> Used memory in bytes */
+        /** @var int<0, max> Peak memory allocated during the iteration, in bytes */
         public int $memory,
 
         /** Sum of time across all calls in microseconds. */

--- a/plugin/bench/src/Internal/BenchHandler.php
+++ b/plugin/bench/src/Internal/BenchHandler.php
@@ -129,15 +129,21 @@ final readonly class BenchHandler
 
     private static function runCase(\Closure $function, int $calls): Snap
     {
-        $beforeMem = \memory_get_usage();
+        # Peak rather than end-to-end delta: a function that frees what it allocated ends where it
+        # started, so the difference would be zero no matter how much it allocated in between. The
+        # peak is reset first so it reflects this iteration only, and the collection cycle keeps
+        # garbage from a previous case out of the window.
+        \gc_collect_cycles();
+        \memory_reset_peak_usage();
+        $beforeMem = \memory_get_peak_usage();
         $beforeTime = \hrtime(true);
         for ($i = 0; $i < $calls; ++$i) {
             $function();
         }
         $afterTime = \hrtime(true);
-        $afterMem = \memory_get_usage();
+        $afterMem = \memory_get_peak_usage();
 
-        $deltaMem = $afterMem - $beforeMem;
+        $deltaMem = \max(0, $afterMem - $beforeMem);
         # Delta time in microseconds
         $deltaTime = ($afterTime - $beforeTime) / 1_000;
         return new Snap(


### PR DESCRIPTION
## Summary

The `Memory` column of a benchmark's iteration table reported `0` for every case, always. It measured the wrong thing: not how much memory a function used, but whether it leaked — and since benchmarked functions normally don't leak, the answer was invariably zero.

This switches the measurement to the peak allocated during the iteration.

## Why it reported zero

`runCase()` sampled `memory_get_usage()` before and after the loop:

```php
$beforeMem = \memory_get_usage();
for ($i = 0; $i < $calls; ++$i) {
    $function();
}
$afterMem = \memory_get_usage();

$deltaMem = $afterMem - $beforeMem;
```

A function that frees what it allocated ends where it started, so the difference collapses to zero no matter how much it allocated in between. The metric only becomes non-zero when memory is still held after the loop — which is a leak, not consumption.

Measured on this repository's own self-benchmarks, the column read `0` in **all 50 rows** of both benchmarks, including `eval1`, which builds a multi-kilobyte string and runs `eval()` on every single call.

## What changed

`plugin/bench/src/Internal/BenchHandler.php` — one method:

```php
\gc_collect_cycles();
\memory_reset_peak_usage();
$beforeMem = \memory_get_peak_usage();
$beforeTime = \hrtime(true);
for ($i = 0; $i < $calls; ++$i) {
    $function();
}
$afterTime = \hrtime(true);
$afterMem = \memory_get_peak_usage();

$deltaMem = \max(0, $afterMem - $beforeMem);
```

Resetting the peak first makes the reading reflect this iteration only; `gc_collect_cycles()` keeps garbage left over by the previous case out of the window.

`plugin/bench/src/Dto/Snap.php` — the `$memory` docblock now says what the field holds ("Peak memory allocated during the iteration") rather than the previous "Used memory in bytes".

Nothing else is touched: no changes to `Renderer`, `formatMemory()`, the DTO shape, or the table layout.

## Results

Iteration table of `Tests\Bench\Self\BenchAttr::sumInCycle`, `Memory` column:

| Case | What it does | Before | After |
| --- | --- | --- | --- |
| `current` | `$result += $i` in a loop | 0 | 0 |
| `sumInArray` | `array_sum(range(1, 5000))` | 0 | 132.05 KB |
| `sumLinearF` | closed-form arithmetic | 0 | 0 |
| `eval1` | builds a large string, `eval()`s it | 0 | 306.97 KB |
| `recursion` | 5000-deep recursion | 0 | 768.00 KB |

The two zeroes that stay zero are the two cases that genuinely allocate nothing, so the column now distinguishes "allocated nothing" from "we cannot tell".

Across all ten iterations of each case the value is byte-for-byte identical. That stability is expected of a memory metric — unlike timing, it should not fluctuate — and it also confirms the reset is doing its job: without it the readings would drift upwards as the process peak accumulated.

## Design notes

**`int<0, max>` is now honest.** The declared type always claimed non-negative, but an end-to-end delta can go negative when the GC frees more than the loop allocated — in which case `formatMemory()` would have printed something like `-1024 B`. A reset-then-baseline reading is non-negative by construction, and `max(0, …)` pins that down.

**PHP 8.2.** `memory_reset_peak_usage()` was added in 8.2, which is exactly this package's floor (`"php": ">=8.2"`), so no constraint change is needed.

**The pattern is already used in this repository.** `tests/Output/Unit/Rendering/Diff/DifferStrategiesTest::peakBytes()` measures the same way — `gc_collect_cycles()`, reset, baseline, delta. This aligns the benchmark plugin with an approach the codebase already relies on rather than introducing a new one.

**Resetting the process-wide peak.** `memory_reset_peak_usage()` affects the whole process, so it is worth stating who else could be disturbed. A search across the repository and its dependencies finds only two other consumers of the memory counters:

- `DifferStrategiesTest::peakBytes()`, which takes its baseline *after* its own reset and is therefore unaffected by anyone else's;
- nothing in `vendor/` reads `memory_get_peak_usage()` at all.

The leak-detection feature is unrelated: `Expect::notLeaks()` works through `\WeakReference` on the tracked objects and never consults memory counters.

As long as every measurement follows "reset, then baseline", they cannot interfere with each other — which is why this change is safe alongside the existing one.

## Verification

| Check | Result |
| --- | --- |
| `composer test:ci` | 1724 tests, 3708 assertions — 1719 passed, 4 risky, 1 flaky |
| `composer rector:ci` | exit 0 |
| `composer infect:ci --filter=plugin/bench` | Covered Code MSI 84% — unchanged from before the patch |

`psalm` and `php-cs-fixer` are configured for `core/` only, so they do not cover this file.

## Notes

- No skill updates needed: the `Memory` column is not described in `skills/testo-benchmarks/SKILL.md` or in the plugin README.
- No `bridge/rector` counterpart: no user-facing test-authoring surface was added.
- Diff is 2 files, +10/−4 — half of it a comment.
