### PR TITLE
fix(vcr): stop requiring ext-soap, and keep an init failure visible

### DIFF
--- a/bridge/vcr/src/Internal/VcrInterceptor.php
+++ b/bridge/vcr/src/Internal/VcrInterceptor.php
@@ -78,11 +78,9 @@ final class VcrInterceptor implements TestRunInterceptor
             PhpVcr::insertCassette($this->options->name);
             return self::runToCompletion($info, $next);
         } finally {
-            # Releasing the guard first, and closing through turnOff() alone: it ejects the cassette
-            # itself and is a no-op when VCR never came on, so a failure inside turnOn() unwinds with
-            # its own exception. A bare eject() here would assert that VCR is running and replace the
-            # real cause with "Please turn on VCR before ejecting a cassette" — and, throwing before
-            # the guard was released, would leave every later #[VCR] test refusing to start.
+            # turnOff() ejects the cassette itself and is a no-op when VCR never came on, so a failure
+            # inside turnOn() unwinds with its own cause. The guard is released first: a throw here
+            # must not leave every later #[VCR] test refusing to start.
             self::$active = false;
             PhpVcr::turnOff();
         }
@@ -98,7 +96,7 @@ final class VcrInterceptor implements TestRunInterceptor
      *
      * Hence the set is stated explicitly, with `soap` added only when it can actually be constructed —
      * the same pair of classes `\VCR\LibraryHooks\SoapHook` checks. HTTP recording keeps working
-     * everywhere; SOAP recording keeps working wherever it could work before.
+     * everywhere; SOAP recording stays available wherever `ext-soap` is installed.
      *
      * @return list<non-empty-string>
      */
@@ -114,11 +112,10 @@ final class VcrInterceptor implements TestRunInterceptor
     /**
      * Run the test to completion without letting a suspension escape the VCR window.
      *
-     * With no surrounding fiber (Testo's current, synchronous mode) the test runs inline. When Testo
-     * runs the test inside a fiber, `$next` is wrapped in a private fiber and resumed here until it
-     * terminates instead of re-suspending to the parent scheduler — keeping the process-global cassette
-     * window atomic. A `#[VCR]` test is therefore expected to be synchronous; awaiting real async work
-     * inside the window is unsupported by design.
+     * With no surrounding fiber the test runs inline. When Testo runs the test inside a fiber, `$next`
+     * is wrapped in a private fiber and resumed here until it terminates instead of re-suspending to the
+     * parent scheduler — keeping the process-global cassette window atomic. A `#[VCR]` test is therefore
+     * expected to be synchronous; awaiting real async work inside the window is unsupported by design.
      *
      * @param callable(TestInfo): TestResult $next
      */

--- a/bridge/vcr/src/Internal/VcrInterceptor.php
+++ b/bridge/vcr/src/Internal/VcrInterceptor.php
@@ -66,21 +66,49 @@ final class VcrInterceptor implements TestRunInterceptor
         );
 
         $configuration = PhpVcr::configure();
+        $configuration->enableLibraryHooks(self::libraryHooks());
         $this->options->mode === null or $configuration->setMode($this->options->mode->value);
         $this->options->match === [] or $configuration->enableRequestMatchers(
             \array_map(static fn(Matcher $m): string => $m->value, $this->options->match),
         );
 
         self::$active = true;
-        PhpVcr::turnOn();
-        PhpVcr::insertCassette($this->options->name);
         try {
+            PhpVcr::turnOn();
+            PhpVcr::insertCassette($this->options->name);
             return self::runToCompletion($info, $next);
         } finally {
-            PhpVcr::eject();
-            PhpVcr::turnOff();
+            # Releasing the guard first, and closing through turnOff() alone: it ejects the cassette
+            # itself and is a no-op when VCR never came on, so a failure inside turnOn() unwinds with
+            # its own exception. A bare eject() here would assert that VCR is running and replace the
+            # real cause with "Please turn on VCR before ejecting a cassette" — and, throwing before
+            # the guard was released, would leave every later #[VCR] test refusing to start.
             self::$active = false;
+            PhpVcr::turnOff();
         }
+    }
+
+    /**
+     * Library hooks php-vcr installs when the window opens.
+     *
+     * Left alone, php-vcr enables every hook it knows — including the SOAP one, whose constructor
+     * hard-requires `ext-soap` and throws from inside `VCR::turnOn()` when it is missing. The extension
+     * is declared `require-dev` by php-vcr itself, so Composer neither installs it for a consumer nor
+     * warns about it: every `#[VCR]` test on a soap-less build dies, whether or not it speaks SOAP.
+     *
+     * Hence the set is stated explicitly, with `soap` added only when it can actually be constructed —
+     * the same pair of classes `\VCR\LibraryHooks\SoapHook` checks. HTTP recording keeps working
+     * everywhere; SOAP recording keeps working wherever it could work before.
+     *
+     * @return list<non-empty-string>
+     */
+    private static function libraryHooks(): array
+    {
+        $hooks = ['stream_wrapper', 'curl'];
+
+        \class_exists(\SoapClient::class) && \class_exists(\DOMDocument::class) and $hooks[] = 'soap';
+
+        return $hooks;
     }
 
     /**


### PR DESCRIPTION
## Summary

On a PHP build without `ext-soap`, **every** `#[VCR]` test failed — whether or not it had anything to do with SOAP. The first failure was genuine but obscure, and the five after it were misleading.

Two changes, both in `VcrInterceptor`: state the library hooks explicitly, and make the cleanup path total.

## Why it failed

### 1. php-vcr treats SOAP as optional in Composer and mandatory at runtime

`php-vcr/php-vcr` 1.12 declares:

```
require:      php, ext-curl, beberlei/assert, symfony/yaml, symfony/event-dispatcher, …
require-dev:  ext-soap, guzzlehttp/guzzle, phpunit, …
suggest:      (empty)
```

`ext-soap` is dev-only. Composer will not install it for a consumer and will not warn about it — by php-vcr's own contract the extension is not needed.

At runtime it is. With no explicit selection, every available hook is enabled:

```php
// VCR\Configuration::getLibraryHooks()
if (null === $this->enabledLibraryHooks) {
    return array_values($this->availableLibraryHooks);   // stream_wrapper, curl, soap
}
```

and `SoapHook`'s constructor refuses to build without the extension:

```php
// VCR\LibraryHooks\SoapHook::__construct()
if (!class_exists('\SoapClient')) {
    throw new \BadMethodCallException('For soap support you need to install the soap extension.');
}
```

That throw happens inside `VCR::turnOn()`, i.e. inside the interceptor, mid-run:

```
bridge/vcr/src/Internal/VcrInterceptor.php  VCR::turnOn()
  → Videorecorder->enableLibraryHooks()
  → VCRFactory::get('VCR\LibraryHooks\SoapHook')
  → new SoapHook(…)  →  BadMethodCallException
```

The bridge neither narrowed the hooks nor declared the extension, so it inherited a hard requirement it never asked for.

### 2. The exclusivity guard latched, turning one failure into six

```php
self::$active = true;
PhpVcr::turnOn();                   // throws here
PhpVcr::insertCassette(…);
try {
    …
} finally {
    PhpVcr::eject();
    PhpVcr::turnOff();
    self::$active = false;          // never reached
}
```

`$active` was set before the `try`, so a failure in `turnOn()` left it `true` for the rest of the process. Every later `#[VCR]` test then hit the guard and reported:

> A php-vcr cassette is already active in this process. #[VCR] tests run against a single global cassette and cannot overlap; do not trigger one `#[VCR]` test from within another.

which points at test nesting — something that never happened. One real error, five false ones, and a diagnosis leading away from the cause.

## What changed

**Hooks are stated explicitly**, with SOAP included only when it can actually be constructed — the same two classes `SoapHook` itself checks:

```php
private static function libraryHooks(): array
{
    $hooks = ['stream_wrapper', 'curl'];

    \class_exists(\SoapClient::class) && \class_exists(\DOMDocument::class) and $hooks[] = 'soap';

    return $hooks;
}
```

HTTP recording works everywhere; SOAP recording works wherever it could work before. Nothing is lost on a build that has the extension.

**The window opens inside the `try`, and closes through `turnOff()` alone:**

```php
self::$active = true;
try {
    PhpVcr::turnOn();
    PhpVcr::insertCassette($this->options->name);
    return self::runToCompletion($info, $next);
} finally {
    self::$active = false;
    PhpVcr::turnOff();
}
```

The dropped `eject()` matters, and dropping it is the point rather than a tidy-up:

```
eject()   without turnOn()  →  VCRException: Please turn on VCR before ejecting a cassette
turnOff() without turnOn()  →  no-op
```

`eject()` asserts that VCR is running, so in a `finally` reached by a failing `turnOn()` it throws and *replaces* the real exception — and, throwing before `self::$active = false`, leaves the guard latched anyway. `turnOff()` is guarded by `if ($this->isOn)` and ejects the cassette itself, so it is both sufficient and safe. Releasing the guard first means even a throwing `turnOff()` cannot latch it.

## Verification

Measured on a PHP 8.4 build with `ext-soap` removed (`class_exists('SoapClient') === false`):

| | Before | After |
| --- | --- | --- |
| `Bridge/Vcr` suites | 2 failed, 4 aborted | **7 of 7 passed** |
| Whole suite | FAILED | **1724 tests — 1719 passed, 4 risky, 1 flaky** |

The remaining 4 risky / 1 flaky are the same ones a build *with* `ext-soap` reports, so the two environments now agree.

Both mechanisms were also confirmed directly:

```
php-vcr, default hooks, no ext-soap   →  BadMethodCallException: For soap support you need to install the soap extension.
same, hooks narrowed as in this patch →  turnOn() succeeded, hooks: stream_wrapper, curl
same, on a build with ext-soap        →  turnOn() succeeded, hooks: stream_wrapper, curl, soap
```

and, replaying the interceptor's structure with a deliberately broken initialisation, the cause now surfaces unmasked:

```
BadMethodCallException: For soap support you need to install the soap extension.
```

Checks, all on the soap-less build:

| Check | Result |
| --- | --- |
| `composer test:ci` | exit 0 |
| `composer rector:ci` | exit 0 |
| `composer psalm:ci` | exit 0 |
| `composer cs:diff` | exit 0 |
| `composer infect:ci --filter=bridge/vcr` | MSI 66% (64% before) |

## Notes

- The alternative — declaring `"ext-soap": "*"` in `bridge/vcr/composer.json` — was rejected: it would impose on every consumer an extension php-vcr itself considers optional, to buy nothing but an earlier error message.
- No skill or `bridge/rector` updates needed: no user-facing surface changed, and `#[VCR]`'s API is untouched.
- Diff is 1 file, +32/−4.
