### PR TITLE
fix(bench): resolve the #303 diagnostics review

### DIFF
--- a/core/Output/JUnit/JUnitPlugin.php
+++ b/core/Output/JUnit/JUnitPlugin.php
@@ -127,9 +127,10 @@ final class JUnitPlugin implements PluginConfigurator
      *        the report. Cases of any other type are skipped entirely — no
      *        `<testsuite>`/`<testcase>` element is emitted for them. Empty array means
      *        all types. Use {@see TestType} cases or custom string identifiers.
-     *        Defaults to {@see TestType::Test} only, since the primary JUnit consumers
-     *        (Infection, CI test reporters) look up class-bound test methods by FQN
-     *        and inline/bench/profile cases would pollute that mapping.
+     *        Defaults to {@see TestType::Test} and {@see TestType::TestInline}, deliberately
+     *        excluding bench/profile cases: the primary JUnit consumers (Infection, CI test
+     *        reporters) look up class-bound test methods by FQN and those cases would pollute
+     *        that mapping.
      */
     public function __construct(
         ?string $outputPath = null,

--- a/core/Output/Rendering/BenchMapper.php
+++ b/core/Output/Rendering/BenchMapper.php
@@ -19,8 +19,8 @@ use Testo\Bench\Dto\Snap;
  * loads any of this.
  *
  * The numbers are taken from {@see Line}, the ranked view the plugin computes: it carries the relative
- * difference against the baseline case and the diagnostics that explain when a measurement should not be
- * trusted. Times stay in microseconds, the unit the plugin measures in — converting here would only add a
+ * difference against the `current` baseline and the diagnostics that explain when a measurement should not
+ * be trusted. Times stay in microseconds, the unit the plugin measures in — converting here would only add a
  * rounding step for the renderer to undo.
  *
  * Two shapes are offered, because the reporters need different ones: {@see map()} for documents that can
@@ -142,7 +142,7 @@ final class BenchMapper
             # Microseconds, as the bench plugin measures.
             'mean' => $line->avg->value,
             'median' => $line->med->value,
-            # Percent against the baseline case: 0.0 for the baseline, positive for slower.
+            # Percent against `current`, the baseline: 0.0 for it, positive for slower, negative for faster.
             'meanDiff' => $line->avg->diff,
             'medianDiff' => $line->med->diff,
             # Standard deviation as a percentage of the mean.

--- a/plugin/bench/Bench.php
+++ b/plugin/bench/Bench.php
@@ -78,7 +78,9 @@ final readonly class Bench implements Interceptable
          *
          * Each entry can be:
          * - A callable (closure, function name, `[object, method]`, etc.)
-         * - An array `[class-string, non-empty-string]` to reference a non-public method by class and name.
+         * - An array `[class-string, non-empty-string]` to reference a non-public method by class and
+         *   name. A static method is called as is; a non-static one is bound to the current test case
+         *   instance, so its class must be the one under test.
          *
          * Use **string keys** to assign aliases that will appear in the results table:
          *

--- a/plugin/bench/Bench.php
+++ b/plugin/bench/Bench.php
@@ -130,10 +130,24 @@ final readonly class Bench implements Interceptable
          * @var int<1, max>
          */
         public int $iterations = 10,
+
+        /**
+         * How much slower `current` may be than the fastest callable before the benchmark fails.
+         *
+         * Expressed as a fraction of the fastest filtered mean: `current` passes while its own
+         * filtered mean stays within `fastest * (1 + $tolerance)`. The default matches the 2% stability
+         * target, leaving that much headroom for measurement noise; raise it for noisier environments,
+         * or set it to `0.0` to demand that `current` be no slower than every alternative. Set it to
+         * `\INF` to compare implementations of equivalent speed without gating on which one wins.
+         *
+         * @var float
+         */
+        public float $tolerance = 0.02,
     ) {
         $warmup >= 0 or throw new \InvalidArgumentException('Warmup must be greater than or equal to 0.');
         \count($callables) >= 1 or throw new \InvalidArgumentException('At least one callable must be provided.');
         $calls > 0 or throw new \InvalidArgumentException('Calls must be greater than 0.');
         $iterations > 0 or throw new \InvalidArgumentException('Iterations must be greater than 0.');
+        $tolerance >= 0.0 or throw new \InvalidArgumentException('Tolerance must be greater than or equal to 0.');
     }
 }

--- a/plugin/bench/Bench.php
+++ b/plugin/bench/Bench.php
@@ -60,9 +60,11 @@ use Testo\Pipeline\Attribute\Interceptable;
  *
  * ## Stability
  *
- * Results are considered stable when the relative standard deviation (RStDev) is below 2%.
- * If variance is too high, Testo will generate diagnostic reports with actionable advice
- * (e.g., increase `$calls` or `$iterations`).
+ * Read the RStDev column to judge a result yourself: below 2% it is reproducible at one
+ * significant figure. That bar is stricter than the diagnostic engine, which stays silent
+ * until variance is pronounced (RStDev around 10% and up) and only then emits reports with
+ * actionable advice (e.g., increase `$calls` or `$iterations`) — a clean report means "nothing
+ * worth acting on", not "below 2%".
  *
  * @link https://php-testo.github.io/blog/collider.md
  *

--- a/plugin/bench/Bench.php
+++ b/plugin/bench/Bench.php
@@ -106,10 +106,12 @@ final readonly class Bench implements Interceptable
         public array $arguments = [],
 
         /**
-         * Number of warmup calls before the actual benchmark iterations.
+         * Number of warmup calls before the actual benchmark iterations; their results are discarded.
          *
-         * Warmup runs eliminate cold-start overhead (lazy initialization, first-call allocations, etc.).
-         * Results from warmup calls are discarded.
+         * The default `1` covers first-call resolution: autoloading, file includes, opcache compilation
+         * and other lazy one-time initialization, which a single call already triggers. It is intentionally
+         * low because the per-call cost is unknown up front. Raise it for JIT-sensitive or cache-sensitive
+         * code, where warming needs many calls to reach a steady state.
          *
          * @var int<0, max>
          */
@@ -120,6 +122,12 @@ final readonly class Bench implements Interceptable
          *
          * Higher values reduce the impact of measurement overhead and produce more stable results.
          * If RStDev is too high, try increasing this value.
+         *
+         * Every measurement includes a fixed per-call harness cost (a closure call and argument
+         * forwarding). It is the same for every callable, so relative ranking stays correct, but for
+         * sub-microsecond functions it dominates the timing and compresses the reported percentages.
+         * It is not subtracted: a faithful baseline would itself depend on argument count and runtime,
+         * so raise `$calls` (or compare relatively) rather than trusting absolute figures at that scale.
          *
          * @var int<1, max>
          */

--- a/plugin/bench/Bench.php
+++ b/plugin/bench/Bench.php
@@ -14,8 +14,9 @@ use Testo\Pipeline\Attribute\Interceptable;
  *
  * The marked method (or function) automatically receives the alias `current`.
  * All callables listed in {@see Bench::$callables} are benchmarked under the same conditions.
- * Results are ranked by filtered average time — the fastest callable takes first place
- * and serves as the baseline for relative comparison.
+ * Results are ranked by filtered average time — the fastest callable takes first place — while the
+ * relative percentages are measured against `current`, the baseline the alternatives are compared to.
+ * The fastest callable and the baseline are independent: `current` need not be the fastest.
  *
  * ## How it works
  *
@@ -26,7 +27,7 @@ use Testo\Pipeline\Attribute\Interceptable;
  *
  * ## Aliases
  *
- * - The marked method always has the alias `current`.
+ * - The marked method always has the alias `current` and is the baseline for relative percentages.
  * - For other callables, use **string keys** in the `$callables` array to assign aliases.
  *   These aliases appear in the results table for easy identification.
  *

--- a/plugin/bench/composer.json
+++ b/plugin/bench/composer.json
@@ -26,6 +26,12 @@
         "testo/inline": "^0.1.8",
         "testo/testo": "0.10.40 - 1"
     },
+    "require-dev": {
+        "testo/assert": "^0.1.12"
+    },
+    "suggest": {
+        "testo/assert": "Enables the benchmark verdict as an assertion: current must be the fastest within tolerance, otherwise the test fails."
+    },
     "autoload": {
         "psr-4": {
             "Testo\\Bench\\": "src/"

--- a/plugin/bench/src/Dto/BenchResult.php
+++ b/plugin/bench/src/Dto/BenchResult.php
@@ -13,7 +13,7 @@ final readonly class BenchResult
         /** @var list<CaseResult> */
         public array $results,
 
-        /** @var list<Line> Res */
+        /** @var list<Line> Prepared report lines, one per case. */
         public array $lines = [],
     ) {}
 }

--- a/plugin/bench/src/Dto/CaseResult.php
+++ b/plugin/bench/src/Dto/CaseResult.php
@@ -16,7 +16,7 @@ final readonly class CaseResult
         /** Median time across all iterations in microseconds. */
         public float $med,
 
-        /** Standard deviation of the time values across all iterations. */
+        /** Relative standard deviation across all iterations, as a percentage of the mean. */
         public float $rstdev,
 
         /** @var int<0, max> Number of iterations that were rejected from the final results. */
@@ -25,7 +25,7 @@ final readonly class CaseResult
         /** Average time across all the filtered iterations in microseconds. */
         public float $favg,
 
-        /** Standard deviation of the time values across all the filtered iterations. */
+        /** Relative standard deviation across the filtered iterations, as a percentage of the filtered mean. */
         public float $frstdev,
     ) {}
 }

--- a/plugin/bench/src/Dto/Report/BimodalBehavior.php
+++ b/plugin/bench/src/Dto/Report/BimodalBehavior.php
@@ -19,7 +19,7 @@ final readonly class BimodalBehavior extends Report
         parent::__construct(
             severity: Severity::Danger,
             reason: 'Bimodal behavior',
-            advice: 'Function has two execution modes — benchmark each separately.',
+            advice: 'Split into separate benchmarks.',
         );
     }
 }

--- a/plugin/bench/src/Dto/Report/ExtremeOutlierRate.php
+++ b/plugin/bench/src/Dto/Report/ExtremeOutlierRate.php
@@ -18,7 +18,7 @@ final readonly class ExtremeOutlierRate extends Report
         parent::__construct(
             severity: Severity::Danger,
             reason: 'Extreme outlier rate',
-            advice: 'Results invalid — split benchmarks or fix environment.',
+            advice: 'Split into separate benchmarks.',
         );
     }
 }

--- a/plugin/bench/src/Dto/Report/HeavilySkewed.php
+++ b/plugin/bench/src/Dto/Report/HeavilySkewed.php
@@ -17,7 +17,7 @@ final readonly class HeavilySkewed extends Report
         parent::__construct(
             severity: Severity::Danger,
             reason: 'Heavily skewed',
-            advice: 'Results unreliable — split into separate benchmarks.',
+            advice: 'Split into separate benchmarks.',
         );
     }
 }

--- a/plugin/bench/src/Dto/Report/HighVarianceLowIterTime.php
+++ b/plugin/bench/src/Dto/Report/HighVarianceLowIterTime.php
@@ -18,7 +18,7 @@ final readonly class HighVarianceLowIterTime extends Report
         parent::__construct(
             severity: Severity::Warning,
             reason: 'High variance, low iter time',
-            advice: 'Measurement overhead may dominate — increase calls per iteration.',
+            advice: 'Increase calls per iteration.',
         );
     }
 }

--- a/plugin/bench/src/Dto/Report/InsufficientIterTime.php
+++ b/plugin/bench/src/Dto/Report/InsufficientIterTime.php
@@ -18,7 +18,7 @@ final readonly class InsufficientIterTime extends Report
         parent::__construct(
             severity: Severity::Warning,
             reason: 'Insufficient iter time',
-            advice: 'Timer jitter exceeds useful signal — increase calls per iteration.',
+            advice: 'Increase calls per iteration.',
         );
     }
 }

--- a/plugin/bench/src/Dto/Report/UnreliableLowIterTime.php
+++ b/plugin/bench/src/Dto/Report/UnreliableLowIterTime.php
@@ -18,7 +18,7 @@ final readonly class UnreliableLowIterTime extends Report
         parent::__construct(
             severity: Severity::Danger,
             reason: 'Unreliable, low iter time',
-            advice: 'Timer overhead dominates — significantly increase calls per iteration.',
+            advice: 'Increase calls per iteration.',
         );
     }
 }

--- a/plugin/bench/src/Dto/ValueRel.php
+++ b/plugin/bench/src/Dto/ValueRel.php
@@ -13,8 +13,8 @@ final readonly class ValueRel
         public float $value,
 
         /**
-         * @var float Difference from the baseline value (the best-performing benchmark) in percentage.
-         *      For the baseline, this will be 0.0. For others, can be positive (worse) or negative (better).
+         * @var float Difference from the baseline — the `current` case — in percentage. Zero for the
+         *      baseline itself; positive means slower than it, negative means faster.
          *
          * The formula for calculating this is: ((current_value - baseline_value) / baseline_value) * 100
          */

--- a/plugin/bench/src/Internal/BenchHandler.php
+++ b/plugin/bench/src/Internal/BenchHandler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Testo\Bench\Internal;
 
+use Testo\Assert\Internal\StaticState;
+use Testo\Assert\State\Assertion\AssertionException;
+use Testo\Assert\State\Assertion\AssertionSuccess;
 use Testo\Bench;
 use Testo\Bench\Dto\BenchResult;
 use Testo\Bench\Dto\CaseResult;
@@ -97,7 +100,75 @@ final readonly class BenchHandler
 
             EOT);
 
+        self::assertCurrentIsFastest($results, $aliases, $attr->tolerance);
+
         return $result;
+    }
+
+    /**
+     * Records the benchmark's verdict as an assertion on the current test: `current` (always case 0)
+     * should be the fastest, with `$tolerance` headroom over the fastest callable for noise. A pass
+     * records a successful assertion — which also keeps the benchmark from being reported as Risky for
+     * asserting nothing; a miss throws, and the runner turns the assertion failure into a Failed test.
+     *
+     * No-op without the Assert plugin (the {@see \class_exists()} guard), so `testo/bench` stays
+     * independent of it.
+     *
+     * @param list<CaseResult> $results Case results, ordered as measured — index 0 is `current`.
+     * @param list<string> $aliases Case aliases in the same order; `$aliases[0]` is `current`.
+     */
+    private static function assertCurrentIsFastest(array $results, array $aliases, float $tolerance): void
+    {
+        if (!\class_exists(StaticState::class)) {
+            return;
+        }
+
+        $record = self::benchmarkVerdict($results, $aliases, $tolerance);
+
+        $state = StaticState::current();
+        $state === null or $state->history[] = $record;
+
+        $record instanceof AssertionException and throw $record;
+    }
+
+    /**
+     * The benchmark's verdict as an assertion record: a successful one when `current` (always case 0)
+     * is the fastest within `$tolerance` headroom over the fastest callable, a failing one naming the
+     * faster callable otherwise. A `$tolerance` of `\INF` always passes.
+     *
+     * @param list<CaseResult> $results Case results, ordered as measured — index 0 is `current`.
+     * @param list<string> $aliases Case aliases in the same order; `$aliases[0]` is `current`.
+     */
+    public static function benchmarkVerdict(
+        array $results,
+        array $aliases,
+        float $tolerance,
+    ): AssertionSuccess|AssertionException {
+        $current = $results[0]->favg;
+        $fastest = $current;
+        $fastestAlias = $aliases[0];
+        foreach ($results as $i => $result) {
+            if ($result->favg < $fastest) {
+                $fastest = $result->favg;
+                $fastestAlias = $aliases[$i];
+            }
+        }
+
+        $assertion = \sprintf('is the fastest within %.0f%%', $tolerance * 100);
+
+        if ($current <= $fastest * (1 + $tolerance)) {
+            return new AssertionSuccess('current', $assertion, '');
+        }
+
+        $slower = $fastest > 0.0 ? ($current / $fastest - 1) * 100 : \INF;
+
+        return new AssertionException(
+            value: 'current',
+            assertion: $assertion,
+            context: '',
+            reason: \sprintf("'%s' is %.1f%% faster", $fastestAlias, $slower),
+            details: '',
+        );
     }
 
     private static function normalizeCallable(TestInfo $info, callable|array $callable): \Closure

--- a/plugin/bench/src/Internal/BenchHandler.php
+++ b/plugin/bench/src/Internal/BenchHandler.php
@@ -173,8 +173,42 @@ final readonly class BenchHandler
 
     private static function normalizeCallable(TestInfo $info, callable|array $callable): \Closure
     {
-        $fn = $callable(...);
+        # A `[class-string, method]` pair may name a non-public method, which the plain first-class
+        # callable syntax cannot invoke; resolve those through reflection. An `[object, method]` pair
+        # and every other callable already close over their target, so keep them as is.
+        if (\is_array($callable) && \is_string($callable[0])) {
+            $case = $info->caseInfo->instance;
+            $instance = $case !== null && $case->hasInstance() ? $case->getInstance() : null;
+            $fn = self::methodClosure($callable[0], $callable[1], $instance);
+        } else {
+            $fn = $callable(...);
+        }
+
         return static fn(): mixed => $fn(...$info->arguments);
+    }
+
+    /**
+     * Resolves a `[class-string, method]` reference to a closure, bypassing visibility so a benchmark
+     * can compare non-public implementations. A static method binds to no instance; a non-static one
+     * binds to `$instance`, which must be an instance of the method's declaring class.
+     *
+     * @param class-string $class
+     * @param non-empty-string $method
+     */
+    public static function methodClosure(string $class, string $method, ?object $instance): \Closure
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+
+        if ($reflection->isStatic()) {
+            return $reflection->getClosure();
+        }
+
+        $instance !== null && $reflection->getDeclaringClass()->isInstance($instance)
+            or throw new \InvalidArgumentException(
+                "Cannot benchmark non-static method {$class}::{$method}() without an instance of {$class}.",
+            );
+
+        return $reflection->getClosure($instance);
     }
 
     /**

--- a/plugin/bench/src/Internal/Calculator.php
+++ b/plugin/bench/src/Internal/Calculator.php
@@ -48,15 +48,15 @@ final class Calculator
             )
             : $averages;
 
-        # Calc RMS of the original averages for relative standard deviation calculation
-        $rms = self::rms(...$averages);
+        # Standard deviation of the original averages for the relative standard deviation
+        $sd = self::stdev(...$averages);
         $avg = self::avg(...$averages);
-        $rstdev = $avg > 0 ? ($rms / $avg) * 100 : 0.0;
+        $rstdev = $avg > 0 ? ($sd / $avg) * 100 : 0.0;
 
-        # Calc RMS, average, and relative standard deviation for the filtered iterations
-        $frms = self::rms(...$filtered);
+        # Standard deviation, average, and relative standard deviation for the filtered iterations
+        $fsd = self::stdev(...$filtered);
         $favg = self::avg(...$filtered);
-        $frstdev = $favg > 0 ? ($frms / $favg) * 100 : 0.0;
+        $frstdev = $favg > 0 ? ($fsd / $favg) * 100 : 0.0;
 
         return new CaseResult(
             mean: self::avg(...$averages),
@@ -87,12 +87,12 @@ final class Calculator
     }
 
     /**
-     * Calculates the root mean square (RMS) of the given values.
+     * Calculates the population standard deviation of the given values (variance over `n`).
      */
     #[TestInline([], result: 0.0)]
     #[TestInline([3.0], result: 0.0)]
     #[TestInline([3.0, 3.0, 3.0, 3.0], result: 0.0)]
-    private static function rms(float ...$values): float
+    private static function stdev(float ...$values): float
     {
         $n = \count($values);
         if ($n === 0) {

--- a/plugin/bench/src/Internal/Calculator.php
+++ b/plugin/bench/src/Internal/Calculator.php
@@ -38,11 +38,15 @@ final class Calculator
         # Set limit for outliers
         $limit = 3 * $mad * 1.4826;
 
-        # Filter out iterations that are considered outliers
-        $filtered = \array_filter(
-            $averages,
-            static fn(float $avg): bool => \abs($avg - $median) <= $limit,
-        );
+        # A zero MAD means a degenerately narrow distribution — over half the samples share a value,
+        # which a coarse timer produces routinely — not that every sample off the median is an outlier.
+        # Filtering on a zero limit would keep only exact-median samples and reject the rest, so skip it.
+        $filtered = $mad > 0.0
+            ? \array_filter(
+                $averages,
+                static fn(float $avg): bool => \abs($avg - $median) <= $limit,
+            )
+            : $averages;
 
         # Calc RMS of the original averages for relative standard deviation calculation
         $rms = self::rms(...$averages);

--- a/plugin/bench/src/Internal/Calculator.php
+++ b/plugin/bench/src/Internal/Calculator.php
@@ -52,7 +52,7 @@ final class Calculator
         # Calc RMS, average, and relative standard deviation for the filtered iterations
         $frms = self::rms(...$filtered);
         $favg = self::avg(...$filtered);
-        $frstdev = $frms / $favg * 100;
+        $frstdev = $favg > 0 ? ($frms / $favg) * 100 : 0.0;
 
         return new CaseResult(
             mean: self::avg(...$averages),

--- a/plugin/bench/src/Internal/Explanator.php
+++ b/plugin/bench/src/Internal/Explanator.php
@@ -40,7 +40,7 @@ final class Explanator
                 name: $cases[$k]->name,
                 avg: new ValueRel(
                     value: $result->mean,
-                    diff: $baseTime > 0 ? ($result->mean - $baseMean) / $baseMean * 100 : 0.0,
+                    diff: $baseMean > 0 ? ($result->mean - $baseMean) / $baseMean * 100 : 0.0,
                 ),
                 med: new ValueRel(
                     value: $result->med,

--- a/plugin/bench/src/Internal/Renderer.php
+++ b/plugin/bench/src/Internal/Renderer.php
@@ -154,37 +154,52 @@ final class Renderer
 
     public static function recommendations(BenchResult $result): string
     {
-        $dangers = [];
-        $warnings = [];
-        $notices = [];
+        $glyphs = [
+            Severity::Danger->name => '✗',
+            Severity::Warning->name => '⚠',
+            Severity::Notice->name => 'ℹ',
+        ];
+        $rank = [
+            Severity::Danger->name => 0,
+            Severity::Warning->name => 1,
+            Severity::Notice->name => 2,
+        ];
 
+        # Group the detected causes by the advice they share, across severities: one fix is printed
+        # once as a heading with every cause that calls for it beneath, each carrying its own icon.
+        # @var array<non-empty-string, list<array{Severity, non-empty-string}>> $groups
+        $groups = [];
+        $seen = [];
         foreach ($result->lines as $line) {
             foreach ($line->reports as $report) {
-                match ($report->severity) {
-                    Severity::Danger => $dangers[$report->reason] = $report->advice,
-                    Severity::Warning => $warnings[$report->reason] = $report->advice,
-                    Severity::Notice => $notices[$report->reason] = $report->advice,
-                    default => null,
-                };
+                $key = $report->severity->name . '|' . $report->reason;
+                if (isset($seen[$report->advice][$key])) {
+                    continue;
+                }
+                $seen[$report->advice][$key] = true;
+                $groups[$report->advice][] = [$report->severity, $report->reason];
             }
         }
 
-        if ($dangers === [] && $warnings === [] && $notices === []) {
+        if ($groups === []) {
             return '';
         }
 
+        # Most severe cause first, both within a group and between groups.
+        $topRank = [];
+        foreach ($groups as $advice => &$causes) {
+            \usort($causes, static fn(array $a, array $b): int => $rank[$a[0]->name] <=> $rank[$b[0]->name]);
+            $topRank[$advice] = $rank[$causes[0][0]->name];
+        }
+        unset($causes);
+        \uksort($groups, static fn(string $a, string $b): int => $topRank[$a] <=> $topRank[$b]);
+
         $lines = ['', 'Recommendations:'];
-
-        foreach ($dangers as $reason => $advice) {
-            $lines[] = "  ✗ {$reason}: {$advice}";
-        }
-
-        foreach ($warnings as $reason => $advice) {
-            $lines[] = "  ⚠ {$reason}: {$advice}";
-        }
-
-        foreach ($notices as $reason => $advice) {
-            $lines[] = "  ℹ {$reason}: {$advice}";
+        foreach ($groups as $advice => $causes) {
+            $lines[] = "  {$advice}";
+            foreach ($causes as [$severity, $reason]) {
+                $lines[] = "      {$glyphs[$severity->name]} {$reason}";
+            }
         }
 
         return \implode("\n", $lines);

--- a/plugin/bench/src/Internal/Renderer.php
+++ b/plugin/bench/src/Internal/Renderer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Testo\Bench\Internal;
 
 use Testo\Bench\Dto\BenchResult;
+use Testo\Bench\Dto\Line;
 use Testo\Bench\Dto\Report;
 use Testo\Bench\Dto\Report\Severity;
 
@@ -28,11 +29,6 @@ final class Renderer
                 $hasRejected = true;
                 break;
             }
-        }
-
-        $callsByName = [];
-        foreach ($result->cases as $case) {
-            $callsByName[$case->name] = $case->iterations[0]->calls;
         }
 
         $headers = ['Name', 'Iters', 'Calls', 'Mean', 'Median', 'RStDev'];
@@ -65,12 +61,17 @@ final class Renderer
         $spans[] = [$summaryStart, $summaryEnd, 'Summary'];
         $summaryStart !== $summaryEnd and $merges[] = [$summaryStart, $summaryEnd];
 
+        # Render fastest first; the keys still index into $result->cases for the call count.
+        $orderedLines = $result->lines;
+        \uasort($orderedLines, static fn(Line $a, Line $b): int => $a->place <=> $b->place);
+
         $rows = [];
-        foreach ($result->lines as $line) {
+        foreach ($orderedLines as $k => $line) {
+            $calls = $result->cases[$k]->iterations[0]->calls ?? 0;
             $row = [
                 $line->name,
                 (string) $iters,
-                (string) ($callsByName[$line->name] ?? 0),
+                (string) $calls,
                 self::formatTime($line->avg->value, $line->avg->diff),
                 self::formatTime($line->med->value, $line->med->diff),
                 $iters > 1 ? self::formatRstdev($line->rstdev) : '',
@@ -89,8 +90,9 @@ final class Renderer
             $rows[] = $row;
         }
 
-        $rightAlign = [5 => true];
+        $rightAlign = [3 => true, 4 => true, 5 => true];
         if ($hasRejected) {
+            $rightAlign[7] = true;
             $rightAlign[8] = true;
         }
 
@@ -341,7 +343,6 @@ final class Renderer
             foreach ($spans as [$from, $to, $label]) {
                 if ($i === $from) {
                     $span = self::spanWidth($widths, $from, $to);
-                    // $result .= ' ' . self::centerPad($label, $span - 2) . ' |';
                     $result .= ' ' . \str_pad(\strtoupper($label), $span - 2) . ' |';
                     $i = $to + 1;
                     $handled = true;

--- a/plugin/bench/src/Internal/Renderer.php
+++ b/plugin/bench/src/Internal/Renderer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Testo\Bench\Internal;
 
 use Testo\Bench\Dto\BenchResult;
-use Testo\Bench\Dto\Line;
 use Testo\Bench\Dto\Report;
 use Testo\Bench\Dto\Report\Severity;
 
@@ -61,12 +60,10 @@ final class Renderer
         $spans[] = [$summaryStart, $summaryEnd, 'Summary'];
         $summaryStart !== $summaryEnd and $merges[] = [$summaryStart, $summaryEnd];
 
-        # Render fastest first; the keys still index into $result->cases for the call count.
-        $orderedLines = $result->lines;
-        \uasort($orderedLines, static fn(Line $a, Line $b): int => $a->place <=> $b->place);
-
+        # Keep declaration order so `current` stays first as the percentage baseline; the keys
+        # index into $result->cases for the call count.
         $rows = [];
-        foreach ($orderedLines as $k => $line) {
+        foreach ($result->lines as $k => $line) {
             $calls = $result->cases[$k]->iterations[0]->calls ?? 0;
             $row = [
                 $line->name,

--- a/plugin/bench/tests/Self/BenchAttr.php
+++ b/plugin/bench/tests/Self/BenchAttr.php
@@ -13,11 +13,13 @@ final class BenchAttr
 {
     #[Bench(
         [
-            'shift' => [self::class, 'sumLinearF2'],
-            'multi' => [self::class, 'sumLinearF3'],
+            'cycle' => [self::class, 'sumInCycle'],
+            'sumInArray' => [self::class, 'sumRange'],
+            'eval1' => [self::class, 'eval1'],
             'recursion' => [self::class, 'rangeSum'],
         ],
-        arguments: [1, 20_000],
+        arguments: [1, 5_000],
+        warmup: 10,
         calls: 20,
         iterations: 10,
     )]
@@ -35,6 +37,17 @@ final class BenchAttr
         return (int) (($d - 1) * $d * 0.5) + $a * $d;
     }
 
+    #[Bench(
+        [
+            'division' => [self::class, 'sumLinearF1'],
+            'multi' => [self::class, 'sumLinearF3'],
+            'recursion' => [self::class, 'rangeSum'],
+        ],
+        arguments: [1, 20_000],
+        calls: 20,
+        iterations: 10,
+        tolerance: \INF,
+    )]
     #[TestInline([1, 2000], 2001000)]
     #[TestInline([24, 2000], 2000724)]
     public static function sumLinearF2(int $a, int $b): int
@@ -50,27 +63,6 @@ final class BenchAttr
         return $a === $b ? $a : $a + self::rangeSum($a + 1, $b);
     }
 
-    // #[Bench(
-    //     [
-    //         'sumInArray' => [self::class, 'sumRange'],
-    //         'sumLinearF' => [self::class, 'sumLinearF1'],
-    //     ],
-    //     arguments: [1, 5_000],
-    //     calls: 20,
-    //     iterations: 10,
-    // )]
-    #[Bench(
-        [
-            'sumInArray' => [self::class, 'sumRange'],
-            'sumLinearF' => [self::class, 'sumLinearF1'],
-            'eval1' => [self::class, 'eval1'],
-            'recursion' => [self::class, 'rangeSum'],
-        ],
-        arguments: [1, 5_000],
-        warmup: 10,
-        calls: 20,
-        iterations: 10,
-    )]
     public static function sumInCycle(int $a, int $b): int
     {
         $result = 0;

--- a/plugin/bench/tests/Self/functions.php
+++ b/plugin/bench/tests/Self/functions.php
@@ -4,14 +4,6 @@ declare(strict_types=1);
 
 use Testo\Bench;
 
-#[Bench(
-    callables: [
-        'multiply' => 'viaMultiply',
-        'shift'    => 'viaShift',
-    ],
-    arguments: [1, 200],
-    calls: 2_000,
-)]
 function viaDivision(int $a, int $b): int
 {
     $d = $b - $a + 1;
@@ -24,6 +16,15 @@ function viaMultiply(int $a, int $b): int
     return (int) (($d - 1) * $d * 0.5) + $a * $d;
 }
 
+#[Bench(
+    callables: [
+        'division' => 'viaDivision',
+        'multiply' => 'viaMultiply',
+    ],
+    arguments: [1, 200],
+    calls: 2_000,
+    tolerance: \INF,
+)]
 function viaShift(int $a, int $b): int
 {
     $d = $b - $a + 1;

--- a/plugin/bench/tests/Unit/BenchMethodClosureTest.php
+++ b/plugin/bench/tests/Unit/BenchMethodClosureTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bench\Unit;
+
+use Testo\Assert;
+use Testo\Bench\Internal\BenchHandler;
+use Testo\Codecov\Covers;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+#[Covers(BenchHandler::class)]
+final class BenchMethodClosureTest
+{
+    public function aPrivateStaticMethodIsInvokable(): void
+    {
+        $fn = BenchHandler::methodClosure(self::subject()::class, 'tripled', null);
+
+        Assert::same($fn(3), 9);
+    }
+
+    public function aPrivateInstanceMethodBindsToTheGivenInstance(): void
+    {
+        $subject = self::subject();
+        $fn = BenchHandler::methodClosure($subject::class, 'doubled', $subject);
+
+        Assert::same($fn(3), 6);
+    }
+
+    public function aNonStaticMethodWithoutAnInstanceIsRejected(): never
+    {
+        Expect::exception(\InvalidArgumentException::class)
+            ->withMessageContaining('without an instance');
+
+        BenchHandler::methodClosure(self::subject()::class, 'doubled', null);
+    }
+
+    public function aNonStaticMethodWithAnInstanceOfAnotherClassIsRejected(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        BenchHandler::methodClosure(self::subject()::class, 'doubled', new \stdClass());
+    }
+
+    private static function subject(): object
+    {
+        return new class {
+            private static function tripled(int $x): int
+            {
+                return $x * 3;
+            }
+
+            private function doubled(int $x): int
+            {
+                return $x * 2;
+            }
+        };
+    }
+}

--- a/plugin/bench/tests/Unit/BenchRecommendationsTest.php
+++ b/plugin/bench/tests/Unit/BenchRecommendationsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bench\Unit;
+
+use Testo\Assert;
+use Testo\Bench\Dto\BenchResult;
+use Testo\Bench\Dto\Line;
+use Testo\Bench\Dto\Report;
+use Testo\Bench\Dto\ValueRel;
+use Testo\Bench\Internal\Renderer;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+#[Test]
+#[Covers(Renderer::class)]
+final class BenchRecommendationsTest
+{
+    public function causesThatShareAdviceCollapseUnderOneHeading(): void
+    {
+        $out = Renderer::recommendations(self::resultWith(
+            new Report\InsufficientIterTime(15.0, 5.0),
+            new Report\HighVarianceLowIterTime(15.0, 5.0),
+        ));
+
+        Assert::same(\substr_count($out, 'Increase calls per iteration.'), 1);
+        Assert::string($out)->contains("  Increase calls per iteration.");
+        Assert::string($out)->contains("      ⚠ Insufficient iter time");
+        Assert::string($out)->contains("      ⚠ High variance, low iter time");
+    }
+
+    public function sharedAdviceGroupsCausesAcrossSeveritiesMostSevereFirst(): void
+    {
+        $out = Renderer::recommendations(self::resultWith(
+            new Report\InsufficientIterTime(15.0, 5.0),
+            new Report\UnreliableLowIterTime(25.0, 5.0),
+        ));
+
+        Assert::same(\substr_count($out, 'Increase calls per iteration.'), 1);
+        Assert::true(
+            \strpos($out, '✗ Unreliable, low iter time') < \strpos($out, '⚠ Insufficient iter time'),
+        );
+    }
+
+    public function distinctAdviceStaysSeparate(): void
+    {
+        $out = Renderer::recommendations(self::resultWith(
+            new Report\InsufficientIterTime(15.0, 5.0),
+            new Report\HighVariance(15.0),
+        ));
+
+        Assert::same(\substr_count($out, 'Increase calls per iteration.'), 1);
+        Assert::same(\substr_count($out, 'Increase iterations or isolate side effects.'), 1);
+    }
+
+    public function noReportsRenderNothing(): void
+    {
+        Assert::same(Renderer::recommendations(self::resultWith()), '');
+    }
+
+    private static function resultWith(Report ...$reports): BenchResult
+    {
+        $zero = new ValueRel(0.0, 0.0);
+        $line = new Line(
+            place: 1,
+            name: 'current',
+            avg: $zero,
+            med: $zero,
+            rstdev: 0.0,
+            favg: $zero,
+            frstdev: 0.0,
+            rejected: 0,
+            reports: $reports,
+        );
+
+        return new BenchResult(cases: [], results: [], lines: [$line]);
+    }
+}

--- a/plugin/bench/tests/Unit/BenchTableTest.php
+++ b/plugin/bench/tests/Unit/BenchTableTest.php
@@ -19,11 +19,11 @@ use Testo\Test;
 #[Covers(Renderer::class)]
 final class BenchTableTest
 {
-    public function rowsAreRenderedFastestFirstRegardlessOfDeclarationOrder(): void
+    public function rowsFollowDeclarationOrderKeepingCurrentFirst(): void
     {
         $out = Renderer::table(self::result());
 
-        Assert::true(\strpos($out, 'fast') < \strpos($out, 'slow'));
+        Assert::true(\strpos($out, 'slow') < \strpos($out, 'fast'));
     }
 
     public function callsAreAttributedPerCaseNotByName(): void

--- a/plugin/bench/tests/Unit/BenchTableTest.php
+++ b/plugin/bench/tests/Unit/BenchTableTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bench\Unit;
+
+use Testo\Assert;
+use Testo\Bench\Dto\BenchResult;
+use Testo\Bench\Dto\CaseResult;
+use Testo\Bench\Dto\CaseSet;
+use Testo\Bench\Dto\Line;
+use Testo\Bench\Dto\Snap;
+use Testo\Bench\Dto\ValueRel;
+use Testo\Bench\Internal\Renderer;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+#[Test]
+#[Covers(Renderer::class)]
+final class BenchTableTest
+{
+    public function rowsAreRenderedFastestFirstRegardlessOfDeclarationOrder(): void
+    {
+        $out = Renderer::table(self::result());
+
+        Assert::true(\strpos($out, 'fast') < \strpos($out, 'slow'));
+    }
+
+    public function callsAreAttributedPerCaseNotByName(): void
+    {
+        $out = Renderer::table(self::result());
+        $lines = \explode("\n", $out);
+
+        $fastRow = self::rowContaining($lines, 'fast');
+        $slowRow = self::rowContaining($lines, 'slow');
+
+        Assert::string($fastRow)->contains('200');
+        Assert::string($slowRow)->contains('100');
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function rowContaining(array $lines, string $needle): string
+    {
+        foreach ($lines as $line) {
+            if (\str_contains($line, $needle)) {
+                return $line;
+            }
+        }
+
+        return '';
+    }
+
+    private static function result(): BenchResult
+    {
+        $slowCase = new CaseSet('slow', [new Snap(100, 0, 200.0), new Snap(100, 0, 200.0)]);
+        $fastCase = new CaseSet('fast', [new Snap(200, 0, 100.0), new Snap(200, 0, 100.0)]);
+
+        $slowLine = self::line(place: 2, name: 'slow', time: 2.0);
+        $fastLine = self::line(place: 1, name: 'fast', time: 1.0);
+
+        # Lines are declared slow-first; their keys index into $cases.
+        return new BenchResult(
+            cases: [$slowCase, $fastCase],
+            results: [],
+            lines: [$slowLine, $fastLine],
+        );
+    }
+
+    private static function line(int $place, string $name, float $time): Line
+    {
+        $value = new ValueRel($time, 0.0);
+
+        return new Line(
+            place: $place,
+            name: $name,
+            avg: $value,
+            med: $value,
+            rstdev: 0.0,
+            favg: $value,
+            frstdev: 0.0,
+            rejected: 0,
+            reports: [],
+        );
+    }
+}

--- a/plugin/bench/tests/Unit/BenchVerdictTest.php
+++ b/plugin/bench/tests/Unit/BenchVerdictTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bench\Unit;
+
+use Testo\Assert;
+use Testo\Bench\Dto\CaseResult;
+use Testo\Bench\Internal\BenchHandler;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+#[Test]
+#[Covers(BenchHandler::class)]
+final class BenchVerdictTest
+{
+    public function currentBeingTheFastestPasses(): void
+    {
+        $record = BenchHandler::benchmarkVerdict(self::results(1.0, 2.0), ['current', 'alt'], 0.02);
+
+        Assert::true($record->isSuccess());
+    }
+
+    public function currentWithinToleranceOfTheFastestPasses(): void
+    {
+        $record = BenchHandler::benchmarkVerdict(self::results(1.02, 1.0), ['current', 'alt'], 0.05);
+
+        Assert::true($record->isSuccess());
+    }
+
+    public function currentSlowerBeyondToleranceFailsAndNamesTheWinner(): void
+    {
+        $record = BenchHandler::benchmarkVerdict(self::results(2.0, 1.0), ['current', 'alt'], 0.02);
+
+        Assert::false($record->isSuccess());
+        Assert::string((string) $record)->contains("'alt' is 100.0% faster");
+    }
+
+    public function infiniteTolerancePassesEvenWhenCurrentIsSlowest(): void
+    {
+        $record = BenchHandler::benchmarkVerdict(self::results(100.0, 1.0), ['current', 'alt'], \INF);
+
+        Assert::true($record->isSuccess());
+    }
+
+    /**
+     * @return list<CaseResult> Case results carrying only the filtered mean the verdict reads.
+     */
+    private static function results(float ...$favg): array
+    {
+        return \array_map(
+            static fn(float $favg): CaseResult => new CaseResult(
+                mean: $favg,
+                med: $favg,
+                rstdev: 0.0,
+                rejected: 0,
+                favg: $favg,
+                frstdev: 0.0,
+            ),
+            $favg,
+        );
+    }
+}

--- a/plugin/bench/tests/Unit/CalculatorTest.php
+++ b/plugin/bench/tests/Unit/CalculatorTest.php
@@ -25,6 +25,16 @@ final class CalculatorTest
         Assert::same($result->rstdev, 0.0);
     }
 
+    public function aZeroMadKeepsEverySampleInsteadOfRejectingTheTail(): void
+    {
+        # Six of ten samples share a value, so the median absolute deviation collapses to zero.
+        $set = self::caseSet([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.1, 10.1, 10.2, 10.2]);
+
+        $result = Calculator::calculate($set);
+
+        Assert::same($result->rejected, 0);
+    }
+
     /**
      * @param list<float> $perCallUs Per-call time of each iteration, in microseconds.
      */

--- a/plugin/bench/tests/Unit/CalculatorTest.php
+++ b/plugin/bench/tests/Unit/CalculatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bench\Unit;
+
+use Testo\Assert;
+use Testo\Bench\Dto\CaseSet;
+use Testo\Bench\Dto\Snap;
+use Testo\Bench\Internal\Calculator;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+#[Test]
+#[Covers(Calculator::class)]
+final class CalculatorTest
+{
+    public function allZeroMeasurementsDoNotDivideByZero(): void
+    {
+        $set = self::caseSet(\array_fill(0, 10, 0.0));
+
+        $result = Calculator::calculate($set);
+
+        Assert::same($result->frstdev, 0.0);
+        Assert::same($result->rstdev, 0.0);
+    }
+
+    /**
+     * @param list<float> $perCallUs Per-call time of each iteration, in microseconds.
+     */
+    private static function caseSet(array $perCallUs): CaseSet
+    {
+        return new CaseSet('probe', \array_map(
+            static fn(float $us): Snap => new Snap(calls: 20, memory: 0, time: $us * 20),
+            $perCallUs,
+        ));
+    }
+}

--- a/skills/testo-benchmarks/SKILL.md
+++ b/skills/testo-benchmarks/SKILL.md
@@ -7,7 +7,9 @@ description: 'Write or tune Testo performance benchmarks with #[Bench]. Use when
 
 `#[Bench]` runs a method many times, collects timing statistics, and reports
 **Mean, Median, RStDev**, with outlier rejection. The stability target is **RStDev < 2%** —
-above that, the result is noisy and shouldn't be used to draw conclusions.
+above that, the result is noisy and shouldn't be used to draw conclusions. This is your own
+bar for reading the RStDev column; the diagnostic engine is more lenient and only emits reports
+once variance is pronounced (RStDev around 10% and up), so a clean report is not a promise of < 2%.
 
 Requires the `BenchmarkPlugin` to be enabled for the suite. Fetch
 `https://php-testo.github.io/llms.txt` for the current `#[Bench]` parameter list — they evolve.

--- a/skills/testo-benchmarks/SKILL.md
+++ b/skills/testo-benchmarks/SKILL.md
@@ -36,7 +36,8 @@ final class SerializationBench
     )]
     public static function encode(): void
     {
-        // Body is unused when `callables` is set — the listed callables are compared head-to-head.
+        // The body is the `current` callable: benchmarked against the listed ones and the baseline
+        // the percentages compare against. Put your current implementation here.
     }
 
     public static function customEncode(array $data): string
@@ -52,6 +53,13 @@ Key parameters:
 - `arguments` — array of positional arguments, applied to every callable.
 - `calls` — invocations per iteration (the inner loop). Increase until per-iteration time is well above timer resolution.
 - `iterations` — number of iterations (the outer loop). Drives the statistics (Mean/Median/RStDev).
+- `tolerance` — how much slower the marked method (`current`) may be than the fastest callable before the benchmark **fails**, as a fraction of the fastest filtered mean (default `0.02`, i.e. 2%).
+
+## Pass / fail
+
+A benchmark records one assertion: `current` is the fastest, within `tolerance`. It **passes** when `current`'s filtered mean stays within `fastest * (1 + tolerance)`, and **fails** (a real test failure) when an alternative beats it by more. So `#[Bench]` doubles as a guard that your current implementation has not regressed against the alternatives you compare it with.
+
+When you compare implementations of *equivalent* speed, the winner is decided by measurement noise and the gate would flake. Set `tolerance: \INF` to compare them without gating on which one wins — the benchmark then only measures and always passes.
 
 ## Selecting or excluding benches
 

--- a/skills/testo-benchmarks/SKILL.md
+++ b/skills/testo-benchmarks/SKILL.md
@@ -101,4 +101,5 @@ When reporting comparison results, **always** include RStDev for each variant. A
 - Don't put assertions inside a benched callable — they inflate the timing and obscure the signal.
 - Don't share state between iterations unless the benchmark is explicitly testing amortized cost.
 - Don't compare benchmarks across machines, CI runners, or PHP versions without re-running both sides on the same host.
-- Don't bench in a method that also uses `#[Test]` or `#[TestInline]` — keep benchmark classes separate.
+
+A method may carry `#[Bench]` together with `#[Test]` or `#[TestInline]` — they run as separate passes, so the inline cases verify correctness while the benchmark measures timing on the same implementation.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,9 +13,9 @@ integrating the Assert module tests into the overall Testo testing process.
 Tests must be isolated from other tests, meaning each module should have
 its own fixtures, mock objects, etc.
 
-Every run writes an HTML report of itself to `runtime/report/index.html` — open it in a browser to inspect
-what ran, with channel output, failures and timings. It is configured in `testo.php` and overwritten by the
-next run.
+Pass `--log-html` (or `--log-report`) to write an HTML report of the run — open it in a browser to inspect
+what ran, with channel output, failures and timings. Without the flag no report is written: the default
+`HtmlPlugin` is inert. The flag with no path uses `runtime/report/index.html`, overwritten by the next run.
 
 ## Self Tests
 


### PR DESCRIPTION
## What was changed

Resolves the full AI diagnostics review in #303, one commit per item.

**Real defects**

- Guard filtered RStDev against a zero mean, so all-zero measurements no longer crash with `DivisionByZeroError`.
- Stop rejecting every off-median sample when MAD is zero, so a degenerately narrow distribution no longer reads as "Results invalid".
- Fail a benchmark when `current` is not the fastest within a new `tolerance` (default 2%, `\INF` disables the gate); a passing benchmark is no longer reported as Risky. The verdict is asserted in the handler and recorded through the Assert soft-dependency.
- Make a `[class-string, method]` callable reach a non-public method: static called as-is, non-static bound to the test-case instance, clear error otherwise.
- Group recommendations by the advice they share instead of repeating identical advice per cause.
- Align the results table's numeric columns, attribute the call count by case index (dropping a latent alias collision), remove dead code, and rename the misnamed `rms()` to `stdev()`.

**Documentation and skill fixes**

- Name `current` as the percentage baseline, distinct from the fastest, and guard the mean percentage against a zero baseline.
- Clarify that the 2% RStDev figure is a reader's bar, not the diagnostic engine's threshold.
- Drop the false "no bench in a `#[Test]`/`#[TestInline]` method" pitfall, which contradicted the framework's own self-tests.
- Describe the HTML report as opt-in via `--log-html`, and match the JUnit `testTypes` docblock to its real default.
- Document the warmup default and the per-call harness overhead as deliberate design choices.

## Why?

The review flagged a mix of real crashes and misleading behaviour (two division-by-zero paths, a false "invalid results" verdict, a passing-but-Risky status, an unusable private-method callable, duplicated recommendation lines, a misaligned table) alongside docs that misdescribed the tool. Item 11 (terminal output ignores `Message` level) is not a defect; level is consumed by the HTML and TeamCity outputs, and a terminal filter is spun out to #306.

## Checklist

- [x] Tests added/updated
- [x] Docs and `testo-benchmarks` skill updated
- [x] Conventional commits, each `Refs #303`

Refs #303
