### PR TITLE
feat(core): add persistent cross-run Store subsystem

### DIFF
--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -19,6 +19,7 @@ use Testo\Application\Internal\Runner\SuiteRunner;
 use Testo\Application\Internal\SuiteProvider;
 use Testo\Common\PluginConfigurator;
 use Testo\Core\Context\RunResult;
+use Testo\Core\Context\SuiteContext;
 use Testo\Core\Context\SuiteResult;
 use Testo\Core\Value\RunTiming;
 use Testo\Core\Value\Status;
@@ -130,6 +131,11 @@ final readonly class Application
                         &$tests,
                     ): ?SuiteResult {
                         $at = \microtime(true);
+
+                        # Make the current suite resolvable from the container before anything runs —
+                        # discovery interceptors and plugins key per-suite state (stores, impact
+                        # selection) off it, and SuiteInfo does not exist yet at this point.
+                        $container->set(new SuiteContext($config->name));
 
                         # Apply plugins first to have all interceptors before suite files scanning
                         self::applyPlugins($container, self::resolvePlugins($config->plugins, SuitePlugins::class));

--- a/core/Application/Config/ApplicationConfig.php
+++ b/core/Application/Config/ApplicationConfig.php
@@ -27,6 +27,7 @@ final readonly class ApplicationConfig
      * @param iterable<PluginConfigurator> $plugins List of plugins to load at the application level (applied to all suites).
      *        An array of plugin instances is treated as {@see ApplicationPlugins::with()}.
      *        Use {@see ApplicationPlugins} facade for advanced configuration.
+     * @param StoreConfig $stores Persistent cross-run storage settings.
      * @see DefaultServicesConfig for default services bindings, which can be overridden.
      */
     public function __construct(
@@ -38,6 +39,7 @@ final readonly class ApplicationConfig
             ),
         ],
         public iterable $plugins = [],
+        public StoreConfig $stores = new StoreConfig(),
     ) {
         $this->src = $src instanceof FinderConfig
             ? $src

--- a/core/Application/Config/DefaultServicesConfig.php
+++ b/core/Application/Config/DefaultServicesConfig.php
@@ -9,10 +9,12 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Testo\Application\Internal\EventDispatcher;
 use Testo\Application\Internal\MessengerHub;
+use Testo\Application\Internal\StoreRegistry;
 use Testo\Pipeline\Internal\OutputInterceptor;
 use Testo\Common\EventListenerCollector;
 use Testo\Common\Messenger;
 use Testo\Common\PluginConfigurator;
+use Testo\Common\Store\Stores;
 use Testo\Event\TestSuite\TestSuiteFinished;
 use Testo\Event\TestSuite\TestSuiteStarting;
 use Testo\Pipeline\InterceptorCollector;
@@ -62,6 +64,8 @@ final readonly class DefaultServicesConfig implements PluginConfigurator
             EventListenerCollector::class => EventDispatcher::class,
             InterceptorCollector::class => InterceptorProvider::class,
             Messenger::class => MessengerHub::class,
+            StoreConfig::class => static fn(Container $c): StoreConfig => $c->get(ApplicationConfig::class)->stores,
+            Stores::class => StoreRegistry::class,
         ];
     }
 

--- a/core/Application/Config/StoreConfig.php
+++ b/core/Application/Config/StoreConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Application\Config;
+
+/**
+ * Configuration of the persistent store subsystem.
+ *
+ * @api
+ */
+final readonly class StoreConfig
+{
+    /**
+     * @param non-empty-string $directory Base directory for all stores. A relative path resolves
+     *        against the process working directory. Overridable at runtime via `TESTO_STORE_DIR`.
+     * @param bool $enabled When `false`, every store is opened in a no-data mode: reads return `null`
+     *        and writes are dropped. Owners need no special-casing — the `load(): null` contract
+     *        already covers "no data yet".
+     */
+    public function __construct(
+        public string $directory = '.testo/store',
+        public bool $enabled = true,
+    ) {}
+}

--- a/core/Application/Internal/Store/FileStore.php
+++ b/core/Application/Internal/Store/FileStore.php
@@ -6,7 +6,6 @@ namespace Testo\Application\Internal\Store;
 
 use Internal\Path;
 use Testo\Common\Messenger;
-use Testo\Common\Store\Store;
 use Testo\Common\Store\StoreDefinition;
 use Testo\Core\Log\Level;
 
@@ -21,7 +20,7 @@ use Testo\Core\Log\Level;
  *
  * @internal
  */
-final class FileStore implements Store
+final class FileStore implements \Testo\Common\Store
 {
     /**
      * Envelope format version, owned by the framework. An unfamiliar layout makes the file count as

--- a/core/Application/Internal/Store/FileStore.php
+++ b/core/Application/Internal/Store/FileStore.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Application\Internal\Store;
+
+use Internal\Path;
+use Testo\Common\Messenger;
+use Testo\Common\Store\Store;
+use Testo\Common\Store\StoreDefinition;
+use Testo\Core\Log\Level;
+
+/**
+ * A store backed by a single JSON file.
+ *
+ * The file holds an envelope — `layout`, `name`, `schema`, `fingerprint`, `updatedAt`, `payload` —
+ * so a read can reject anything that no longer matches the definition. Writes are atomic (temp file
+ * in the same directory, then rename), so a reader never sees a half-written file. {@see update()}
+ * serializes read-modify-write with an advisory lock. Every I/O failure is a swallowed diagnostic,
+ * never a thrown error — a store must not be able to fail a run.
+ *
+ * @internal
+ */
+final readonly class FileStore implements Store
+{
+    /**
+     * Envelope format version, owned by the framework. An unfamiliar layout makes the file count as
+     * absent — old files never get misread after the envelope shape changes.
+     */
+    private const LAYOUT = 1;
+
+    /**
+     * Seconds to wait for the update lock before giving up and skipping the write.
+     */
+    private const LOCK_TIMEOUT = 5.0;
+
+    public function __construct(
+        private Path $baseDir,
+        private Path $path,
+        private StoreDefinition $definition,
+        private Messenger $messenger,
+    ) {}
+
+    #[\Override]
+    public function load(): ?array
+    {
+        $file = (string) $this->path;
+        if (!\is_file($file)) {
+            return null;
+        }
+
+        $raw = @\file_get_contents($file);
+        if ($raw === false) {
+            $this->warn('unreadable');
+            return null;
+        }
+
+        return $this->decode($raw);
+    }
+
+    #[\Override]
+    public function save(array $payload): void
+    {
+        $this->writeAtomic($this->envelope($payload));
+    }
+
+    #[\Override]
+    public function update(\Closure $fn): void
+    {
+        if (!$this->ensureDir()) {
+            return;
+        }
+
+        $handle = @\fopen((string) $this->path . '.lock', 'c');
+        if ($handle === false) {
+            $this->warn('lock unavailable');
+            return;
+        }
+
+        try {
+            if (!$this->acquire($handle)) {
+                $this->warn('lock timeout');
+                return;
+            }
+
+            $this->writeAtomic($this->envelope($fn($this->load())));
+        } finally {
+            @\flock($handle, \LOCK_UN);
+            @\fclose($handle);
+        }
+    }
+
+    #[\Override]
+    public function delete(): void
+    {
+        @\unlink((string) $this->path);
+    }
+
+    /**
+     * @return array<array-key, mixed>|null
+     */
+    private function decode(string $raw): ?array
+    {
+        try {
+            /** @var mixed $data */
+            $data = \json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $this->warn('corrupted');
+            return null;
+        }
+
+        if (
+            !\is_array($data)
+            || ($data['layout'] ?? null) !== self::LAYOUT
+            || ($data['name'] ?? null) !== $this->definition->name
+        ) {
+            $this->warn('corrupted');
+            return null;
+        }
+
+        if (($data['schema'] ?? null) !== $this->definition->schema) {
+            $this->warn('schema mismatch');
+            return null;
+        }
+
+        $stored = $data['fingerprint'] ?? null;
+        $current = $this->fingerprint();
+        \is_array($stored) and \ksort($stored);
+        \ksort($current);
+        if ($stored !== $current) {
+            $this->warn('fingerprint drift');
+            return null;
+        }
+
+        $payload = $data['payload'] ?? null;
+
+        return \is_array($payload) ? $payload : null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $payload
+     * @return array<string, mixed>
+     */
+    private function envelope(array $payload): array
+    {
+        return [
+            'layout' => self::LAYOUT,
+            'name' => $this->definition->name,
+            'schema' => $this->definition->schema,
+            'fingerprint' => $this->fingerprint(),
+            'updatedAt' => \gmdate(\DATE_ATOM),
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fingerprint(): array
+    {
+        $result = [];
+        foreach ($this->definition->fingerprint as $contributor) {
+            $result[$contributor->key()] = $contributor->value();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    private function writeAtomic(array $envelope): void
+    {
+        if (!$this->ensureDir()) {
+            return;
+        }
+
+        try {
+            $json = \json_encode($envelope, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        } catch (\JsonException $e) {
+            $this->warn('encode failed: ' . $e->getMessage());
+            return;
+        }
+
+        $dir = (string) $this->path->parent();
+        $tmp = $dir . '/' . \uniqid('.store-', true) . '.tmp';
+
+        if (@\file_put_contents($tmp, $json, \LOCK_EX) === false || !@\rename($tmp, (string) $this->path)) {
+            @\unlink($tmp);
+            $this->warn('write failed');
+        }
+    }
+
+    private function ensureDir(): bool
+    {
+        if (!$this->ensureBase()) {
+            return false;
+        }
+
+        $dir = (string) $this->path->parent();
+        if (\is_dir($dir) || @\mkdir($dir, 0777, true) || \is_dir($dir)) {
+            return true;
+        }
+
+        $this->warn('directory unavailable');
+        return false;
+    }
+
+    /**
+     * Create the base directory on first write and mark it self-ignoring — the store must never be
+     * committed. A missing .gitignore is not worth failing a run over, so its write is best-effort.
+     */
+    private function ensureBase(): bool
+    {
+        $base = (string) $this->baseDir;
+        if (!\is_dir($base) && !@\mkdir($base, 0777, true) && !\is_dir($base)) {
+            $this->warn('directory unavailable');
+            return false;
+        }
+
+        $gitignore = $base . '/.gitignore';
+        \is_file($gitignore) or @\file_put_contents($gitignore, "*\n");
+
+        return true;
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private function acquire($handle): bool
+    {
+        $deadline = \microtime(true) + self::LOCK_TIMEOUT;
+        do {
+            if (@\flock($handle, \LOCK_EX | \LOCK_NB)) {
+                return true;
+            }
+            \usleep(20_000);
+        } while (\microtime(true) < $deadline);
+
+        return false;
+    }
+
+    private function warn(string $reason): void
+    {
+        $this->messenger->log(
+            Messenger::CHANNEL_STDERR,
+            \sprintf('Store "%s" skipped: %s (%s).', $this->definition->name, $reason, $this->path),
+            Level::Warning,
+        );
+    }
+}

--- a/core/Application/Internal/Store/FileStore.php
+++ b/core/Application/Internal/Store/FileStore.php
@@ -21,7 +21,7 @@ use Testo\Core\Log\Level;
  *
  * @internal
  */
-final readonly class FileStore implements Store
+final class FileStore implements Store
 {
     /**
      * Envelope format version, owned by the framework. An unfamiliar layout makes the file count as
@@ -30,15 +30,30 @@ final readonly class FileStore implements Store
     private const LAYOUT = 1;
 
     /**
-     * Seconds to wait for the update lock before giving up and skipping the write.
+     * Fingerprint values, captured once per opened store: contributors describe the environment,
+     * which is stable within a run, and re-evaluating them per call would re-hash files repeatedly.
+     *
+     * @var array<string, string>|null
      */
-    private const LOCK_TIMEOUT = 5.0;
+    private ?array $fingerprint = null;
 
+    /**
+     * Reasons already reported, so a repeatedly touched store diagnoses each problem once.
+     *
+     * @var array<string, true>
+     */
+    private array $warned = [];
+
+    /**
+     * @param float $lockTimeout Seconds to wait for the update lock before giving up and skipping
+     *        the write.
+     */
     public function __construct(
-        private Path $baseDir,
-        private Path $path,
-        private StoreDefinition $definition,
-        private Messenger $messenger,
+        private readonly Path $baseDir,
+        private readonly Path $path,
+        private readonly StoreDefinition $definition,
+        private readonly Messenger $messenger,
+        private readonly float $lockTimeout = 5.0,
     ) {}
 
     #[\Override]
@@ -83,7 +98,8 @@ final readonly class FileStore implements Store
                 return;
             }
 
-            $this->writeAtomic($this->envelope($fn($this->load())));
+            $next = $fn($this->load());
+            $next === null or $this->writeAtomic($this->envelope($next));
         } finally {
             @\flock($handle, \LOCK_UN);
             @\fclose($handle);
@@ -94,6 +110,7 @@ final readonly class FileStore implements Store
     public function delete(): void
     {
         @\unlink((string) $this->path);
+        @\unlink((string) $this->path . '.lock');
     }
 
     /**
@@ -133,8 +150,12 @@ final readonly class FileStore implements Store
         }
 
         $payload = $data['payload'] ?? null;
+        if (!\is_array($payload)) {
+            $this->warn('corrupted');
+            return null;
+        }
 
-        return \is_array($payload) ? $payload : null;
+        return $payload;
     }
 
     /**
@@ -158,12 +179,16 @@ final readonly class FileStore implements Store
      */
     private function fingerprint(): array
     {
+        if ($this->fingerprint !== null) {
+            return $this->fingerprint;
+        }
+
         $result = [];
         foreach ($this->definition->fingerprint as $contributor) {
             $result[$contributor->key()] = $contributor->value();
         }
 
-        return $result;
+        return $this->fingerprint = $result;
     }
 
     /**
@@ -229,7 +254,7 @@ final readonly class FileStore implements Store
      */
     private function acquire($handle): bool
     {
-        $deadline = \microtime(true) + self::LOCK_TIMEOUT;
+        $deadline = \microtime(true) + $this->lockTimeout;
         do {
             if (@\flock($handle, \LOCK_EX | \LOCK_NB)) {
                 return true;
@@ -242,6 +267,11 @@ final readonly class FileStore implements Store
 
     private function warn(string $reason): void
     {
+        if (isset($this->warned[$reason])) {
+            return;
+        }
+
+        $this->warned[$reason] = true;
         $this->messenger->log(
             Messenger::CHANNEL_STDERR,
             \sprintf('Store "%s" skipped: %s (%s).', $this->definition->name, $reason, $this->path),

--- a/core/Application/Internal/Store/NullStore.php
+++ b/core/Application/Internal/Store/NullStore.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Testo\Application\Internal\Store;
 
-use Testo\Common\Store\Store;
+use Testo\Common\Store;
 
 /**
  * The store handed out when the subsystem is disabled: no data, no writes.

--- a/core/Application/Internal/Store/NullStore.php
+++ b/core/Application/Internal/Store/NullStore.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Application\Internal\Store;
+
+use Testo\Common\Store\Store;
+
+/**
+ * The store handed out when the subsystem is disabled: no data, no writes.
+ *
+ * Indistinguishable to the owner from "nothing has been recorded yet" — {@see load()} returns `null`,
+ * mutations are dropped. `$fn` in {@see update()} is deliberately not invoked: there is no data to
+ * modify and nothing to persist.
+ *
+ * @internal
+ */
+final readonly class NullStore implements Store
+{
+    #[\Override]
+    public function load(): ?array
+    {
+        return null;
+    }
+
+    #[\Override]
+    public function save(array $payload): void {}
+
+    #[\Override]
+    public function update(\Closure $fn): void {}
+
+    #[\Override]
+    public function delete(): void {}
+}

--- a/core/Application/Internal/StoreRegistry.php
+++ b/core/Application/Internal/StoreRegistry.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Application\Internal;
+
+use Internal\Container\Container;
+use Internal\Path;
+use Testo\Application\Config\StoreConfig;
+use Testo\Application\Internal\Store\FileStore;
+use Testo\Application\Internal\Store\NullStore;
+use Testo\Common\Messenger;
+use Testo\Common\Store\Store;
+use Testo\Common\Store\StoreDefinition;
+use Testo\Common\Store\Stores;
+use Testo\Common\Store\StoreScope;
+use Testo\Core\Context\SuiteContext;
+
+/**
+ * Default {@see Stores} implementation.
+ *
+ * A single application-scoped service. It holds the live container rather than a captured scope, so a
+ * suite-scoped {@see open()} resolves the {@see SuiteContext} of whichever suite is active at call
+ * time — the same lazy-resolution seam {@see SuiteProvider} uses. Opening does no I/O; the returned
+ * {@see FileStore} touches disk only when read or written.
+ *
+ * @internal
+ */
+final readonly class StoreRegistry implements Stores
+{
+    public function __construct(
+        private Container $container,
+        private StoreConfig $config,
+        private Messenger $messenger,
+    ) {}
+
+    #[\Override]
+    public function open(StoreDefinition $definition): Store
+    {
+        if (!$this->config->enabled) {
+            return new NullStore();
+        }
+
+        $base = $this->baseDir();
+        $file = match ($definition->scope) {
+            StoreScope::Application => $base->join('app', $definition->name . '.json'),
+            StoreScope::Suite => $this->suiteDir($base)->join($definition->name . '.json'),
+        };
+
+        return new FileStore($base, $file, $definition, $this->messenger);
+    }
+
+    private function baseDir(): Path
+    {
+        $env = \getenv('TESTO_STORE_DIR');
+        $dir = $env === false || $env === '' ? $this->config->directory : $env;
+
+        return Path::create($dir)->absolute();
+    }
+
+    private function suiteDir(Path $base): Path
+    {
+        $this->container->has(SuiteContext::class) or throw new \LogicException(
+            'A suite-scoped store can only be opened within a suite scope.',
+        );
+
+        $name = $this->container->get(SuiteContext::class)->name;
+        # A hash suffix disambiguates slug collisions and case-insensitive filesystems.
+        $slug = self::slug($name) . '-' . \substr(\sha1($name), 0, 8);
+
+        return $base->join('suite', $slug);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function slug(string $name): string
+    {
+        $slug = \trim((string) \preg_replace('/[^a-z0-9]+/', '-', \strtolower($name)), '-');
+
+        return \substr($slug, 0, 40) ?: 'suite';
+    }
+}

--- a/core/Application/Internal/StoreRegistry.php
+++ b/core/Application/Internal/StoreRegistry.php
@@ -10,7 +10,7 @@ use Testo\Application\Config\StoreConfig;
 use Testo\Application\Internal\Store\FileStore;
 use Testo\Application\Internal\Store\NullStore;
 use Testo\Common\Messenger;
-use Testo\Common\Store\Store;
+use Testo\Common\Store;
 use Testo\Common\Store\StoreDefinition;
 use Testo\Common\Store\Stores;
 use Testo\Common\Store\StoreScope;

--- a/core/Application/Internal/StoreRegistry.php
+++ b/core/Application/Internal/StoreRegistry.php
@@ -37,17 +37,17 @@ final readonly class StoreRegistry implements Stores
     #[\Override]
     public function open(StoreDefinition $definition): Store
     {
-        if (!$this->config->enabled) {
-            return new NullStore();
-        }
-
+        # Scope validation is a programming-error check — it must fire regardless of configuration,
+        # or a plugin bug would surface only for users who happen to have stores enabled.
         $base = $this->baseDir();
         $file = match ($definition->scope) {
             StoreScope::Application => $base->join('app', $definition->name . '.json'),
             StoreScope::Suite => $this->suiteDir($base)->join($definition->name . '.json'),
         };
 
-        return new FileStore($base, $file, $definition, $this->messenger);
+        return $this->config->enabled
+            ? new FileStore($base, $file, $definition, $this->messenger)
+            : new NullStore();
     }
 
     private function baseDir(): Path

--- a/core/Application/Internal/StoreRegistry.php
+++ b/core/Application/Internal/StoreRegistry.php
@@ -50,6 +50,16 @@ final readonly class StoreRegistry implements Stores
             : new NullStore();
     }
 
+    /**
+     * @return non-empty-string
+     */
+    private static function slug(string $name): string
+    {
+        $slug = \trim((string) \preg_replace('/[^a-z0-9]+/', '-', \strtolower($name)), '-');
+
+        return \substr($slug, 0, 40) ?: 'suite';
+    }
+
     private function baseDir(): Path
     {
         $env = \getenv('TESTO_STORE_DIR');
@@ -69,15 +79,5 @@ final readonly class StoreRegistry implements Stores
         $slug = self::slug($name) . '-' . \substr(\sha1($name), 0, 8);
 
         return $base->join('suite', $slug);
-    }
-
-    /**
-     * @return non-empty-string
-     */
-    private static function slug(string $name): string
-    {
-        $slug = \trim((string) \preg_replace('/[^a-z0-9]+/', '-', \strtolower($name)), '-');
-
-        return \substr($slug, 0, 40) ?: 'suite';
     }
 }

--- a/core/Common/Store.php
+++ b/core/Common/Store.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Testo\Common\Store;
+namespace Testo\Common;
 
 /**
  * A single opened store: a named, versioned document that survives between runs.

--- a/core/Common/Store/Fingerprint/Extensions.php
+++ b/core/Common/Store/Fingerprint/Extensions.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store\Fingerprint;
+
+use Testo\Common\Store\FingerprintContributor;
+
+/**
+ * Invalidates a store when the presence or version of the named PHP extensions changes. TIA uses it
+ * for coverage drivers (`pcov`, `xdebug`): swapping the driver changes the observed coverage, so the
+ * recorded impact data no longer describes what this environment would produce.
+ *
+ * @api
+ */
+final readonly class Extensions implements FingerprintContributor
+{
+    /** @var non-empty-list<non-empty-string> */
+    private array $names;
+
+    /**
+     * @param non-empty-string ...$names Extension names, order-insensitive.
+     */
+    public function __construct(string ...$names)
+    {
+        $names === [] and throw new \InvalidArgumentException('At least one extension name is required.');
+        \sort($names);
+        $this->names = $names;
+    }
+
+    #[\Override]
+    public function key(): string
+    {
+        return 'ext';
+    }
+
+    #[\Override]
+    public function value(): string
+    {
+        $parts = \array_map(
+            static function (string $name): string {
+                $version = \phpversion($name);
+                return $name . ':' . ($version === false ? '-' : $version);
+            },
+            $this->names,
+        );
+
+        return \implode(';', $parts);
+    }
+}

--- a/core/Common/Store/Fingerprint/FileHash.php
+++ b/core/Common/Store/Fingerprint/FileHash.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store\Fingerprint;
+
+use Internal\Path;
+use Testo\Common\Store\FingerprintContributor;
+
+/**
+ * Invalidates a store when a file's content changes. Typical targets: `composer.lock` (dependency
+ * versions), `testo.php` (run configuration). A relative path resolves against the process working
+ * directory, like every other path Testo reads.
+ *
+ * @api
+ */
+final readonly class FileHash implements FingerprintContributor
+{
+    private Path $path;
+
+    public function __construct(Path|string $path)
+    {
+        $this->path = Path::create($path);
+    }
+
+    #[\Override]
+    public function key(): string
+    {
+        return (string) $this->path;
+    }
+
+    #[\Override]
+    public function value(): string
+    {
+        $file = (string) $this->path;
+        # A missing file is a stable, distinct value: its appearance or removal is itself a change.
+        if (!\is_file($file)) {
+            return 'absent';
+        }
+
+        $hash = @\hash_file('xxh128', $file);
+
+        return $hash === false ? 'unreadable' : 'xxh128:' . $hash;
+    }
+}

--- a/core/Common/Store/Fingerprint/PhpVersion.php
+++ b/core/Common/Store/Fingerprint/PhpVersion.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store\Fingerprint;
+
+use Testo\Common\Store\FingerprintContributor;
+
+/**
+ * Invalidates a store when the PHP minor version changes. Patch releases are ignored: they do not
+ * change tokenization or observable coverage, so re-recording on every patch bump would be waste.
+ *
+ * @api
+ */
+final readonly class PhpVersion implements FingerprintContributor
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'php';
+    }
+
+    #[\Override]
+    public function value(): string
+    {
+        return \PHP_MAJOR_VERSION . '.' . \PHP_MINOR_VERSION;
+    }
+}

--- a/core/Common/Store/FingerprintContributor.php
+++ b/core/Common/Store/FingerprintContributor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store;
+
+/**
+ * One contribution to a store's environment fingerprint.
+ *
+ * The fingerprint is recomputed on every {@see Store::load()} and compared against what was recorded
+ * on the last {@see Store::save()}. Any divergence makes the stored payload count as absent, so a
+ * store never serves data captured under conditions that no longer hold (a different PHP version, a
+ * changed lockfile, a swapped coverage driver).
+ *
+ * @api
+ */
+interface FingerprintContributor
+{
+    /**
+     * Stable identifier of this contribution, unique within one fingerprint: `php`, `composer.lock`.
+     *
+     * @return non-empty-string
+     */
+    public function key(): string;
+
+    /**
+     * Current value to compare against the recorded one: a version, a content hash, a marker.
+     *
+     * @return non-empty-string
+     */
+    public function value(): string;
+}

--- a/core/Common/Store/FingerprintContributor.php
+++ b/core/Common/Store/FingerprintContributor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Testo\Common\Store;
 
+use Testo\Common\Store;
+
 /**
  * One contribution to a store's environment fingerprint.
  *

--- a/core/Common/Store/FingerprintContributor.php
+++ b/core/Common/Store/FingerprintContributor.php
@@ -7,10 +7,11 @@ namespace Testo\Common\Store;
 /**
  * One contribution to a store's environment fingerprint.
  *
- * The fingerprint is recomputed on every {@see Store::load()} and compared against what was recorded
- * on the last {@see Store::save()}. Any divergence makes the stored payload count as absent, so a
- * store never serves data captured under conditions that no longer hold (a different PHP version, a
- * changed lockfile, a swapped coverage driver).
+ * The fingerprint is captured once per opened store — on its first read or write — and compared
+ * against what was recorded on the last {@see Store::save()}. Any divergence makes the stored payload
+ * count as absent, so a store never serves data captured under conditions that no longer hold (a
+ * different PHP version, a changed lockfile, a swapped coverage driver). Contributors describe the
+ * environment, which is stable within a run, so {@see value()} is not re-evaluated per call.
  *
  * @api
  */

--- a/core/Common/Store/Store.php
+++ b/core/Common/Store/Store.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store;
+
+/**
+ * A single opened store: a named, versioned document that survives between runs.
+ *
+ * A store is **never a source of truth**. Its whole contents may vanish — deleted, corrupted, or
+ * invalidated by a fingerprint change — and the next run must still work, only slower. Every method
+ * is fail-open: I/O failures are reported as diagnostics and swallowed, they never change the run's
+ * outcome. Only programming errors (opening a suite store outside a suite scope) throw.
+ *
+ * This interface is meant to be **consumed, not implemented** by userland code. The implementation is
+ * provided by the framework via {@see Stores::open()}.
+ *
+ * @api
+ */
+interface Store
+{
+    /**
+     * Read the payload, or `null` when there is nothing usable to read — the store is absent,
+     * corrupted, has a different schema, or its fingerprint drifted. These are one state to the
+     * caller; the reason survives only as a diagnostic.
+     *
+     * @return array<array-key, mixed>|null
+     */
+    public function load(): ?array;
+
+    /**
+     * Overwrite the payload atomically, stamping it with the current schema and fingerprint. A
+     * partially written file is never observable. On an I/O failure the write is dropped, not thrown.
+     *
+     * @param array<array-key, mixed> $payload
+     */
+    public function save(array $payload): void;
+
+    /**
+     * Read-modify-write under an exclusive lock: `$fn` receives the current payload (or `null`) and
+     * returns the next one, which is then written atomically. Use for incremental updates — merging a
+     * run's outcomes, bumping counters. `$fn` is not invoked when the lock cannot be acquired.
+     *
+     * @param \Closure(array<array-key, mixed>|null): array<array-key, mixed> $fn
+     */
+    public function update(\Closure $fn): void;
+
+    /**
+     * Remove the store from disk. Silent and idempotent.
+     */
+    public function delete(): void;
+}

--- a/core/Common/Store/Store.php
+++ b/core/Common/Store/Store.php
@@ -38,10 +38,12 @@ interface Store
 
     /**
      * Read-modify-write under an exclusive lock: `$fn` receives the current payload (or `null`) and
-     * returns the next one, which is then written atomically. Use for incremental updates — merging a
-     * run's outcomes, bumping counters. `$fn` is not invoked when the lock cannot be acquired.
+     * returns the next one, which is then written atomically — or `null` to leave the store untouched.
+     * Use for incremental updates — merging a run's outcomes, bumping counters. `$fn` is not invoked
+     * when the lock cannot be acquired. Not reentrant: a nested `update()` of the same store stalls
+     * until the lock attempt times out, and the inner write is skipped.
      *
-     * @param \Closure(array<array-key, mixed>|null): array<array-key, mixed> $fn
+     * @param \Closure(array<array-key, mixed>|null): (array<array-key, mixed>|null) $fn
      */
     public function update(\Closure $fn): void;
 

--- a/core/Common/Store/StoreDefinition.php
+++ b/core/Common/Store/StoreDefinition.php
@@ -6,7 +6,8 @@ namespace Testo\Common\Store;
 
 /**
  * Declaration of a store: what it is called, which payload version it carries, where it lives, and
- * what invalidates it. Immutable — typically a constant on the owning plugin.
+ * what invalidates it. Immutable — build it once in a static factory on the owning plugin (PHP does
+ * not allow `new` in class constants).
  *
  * @api
  */
@@ -14,13 +15,14 @@ final readonly class StoreDefinition
 {
     /**
      * @param non-empty-string $name Dotted, lowercase name namespaced by owner: `impact.index`,
-     *        `retry.flaky-history`. Doubles as the on-disk file name.
+     *        `retry.flaky-history`, `symfony-console.cache`. Doubles as the on-disk file name.
      * @param int $schema Payload schema version, >= 1. A recorded payload with a different schema
      *        counts as absent — there are no migrations, the owner rebuilds from scratch.
      * @param StoreScope $scope Whether the document is shared per run or kept per suite.
      * @param list<FingerprintContributor> $fingerprint Environment inputs that invalidate the payload
-     *        when they change. The owner adds its own (e.g. a hash of its config) when it wants the
-     *        store dropped on a configuration change — the suite key itself is only the suite name.
+     *        when they change. Keys must be unique within the list. The owner adds its own (e.g. a
+     *        hash of its config) when it wants the store dropped on a configuration change — the
+     *        suite key itself is only the suite name.
      */
     public function __construct(
         public string $name,
@@ -28,11 +30,21 @@ final readonly class StoreDefinition
         public StoreScope $scope = StoreScope::Suite,
         public array $fingerprint = [],
     ) {
-        \preg_match('/^[a-z0-9]+(\.[a-z0-9-]+)*$/', $name) === 1 or throw new \InvalidArgumentException(
-            \sprintf('Store name must be dotted lowercase (e.g. "impact.index"), "%s" given.', $name),
-        );
+        \preg_match('/^[a-z0-9]+(-[a-z0-9]+)*(\.[a-z0-9]+(-[a-z0-9]+)*)*$/', $name) === 1
+            or throw new \InvalidArgumentException(
+                \sprintf('Store name must be dotted lowercase (e.g. "impact.index"), "%s" given.', $name),
+            );
         $schema >= 1 or throw new \InvalidArgumentException(
             \sprintf('Store schema version must be >= 1, %d given.', $schema),
         );
+
+        $keys = [];
+        foreach ($fingerprint as $contributor) {
+            $key = $contributor->key();
+            isset($keys[$key]) and throw new \InvalidArgumentException(
+                \sprintf('Duplicate fingerprint key "%s" in store "%s".', $key, $name),
+            );
+            $keys[$key] = true;
+        }
     }
 }

--- a/core/Common/Store/StoreDefinition.php
+++ b/core/Common/Store/StoreDefinition.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store;
+
+/**
+ * Declaration of a store: what it is called, which payload version it carries, where it lives, and
+ * what invalidates it. Immutable — typically a constant on the owning plugin.
+ *
+ * @api
+ */
+final readonly class StoreDefinition
+{
+    /**
+     * @param non-empty-string $name Dotted, lowercase name namespaced by owner: `impact.index`,
+     *        `retry.flaky-history`. Doubles as the on-disk file name.
+     * @param int $schema Payload schema version, >= 1. A recorded payload with a different schema
+     *        counts as absent — there are no migrations, the owner rebuilds from scratch.
+     * @param StoreScope $scope Whether the document is shared per run or kept per suite.
+     * @param list<FingerprintContributor> $fingerprint Environment inputs that invalidate the payload
+     *        when they change. The owner adds its own (e.g. a hash of its config) when it wants the
+     *        store dropped on a configuration change — the suite key itself is only the suite name.
+     */
+    public function __construct(
+        public string $name,
+        public int $schema,
+        public StoreScope $scope = StoreScope::Suite,
+        public array $fingerprint = [],
+    ) {
+        \preg_match('/^[a-z0-9]+(\.[a-z0-9-]+)*$/', $name) === 1 or throw new \InvalidArgumentException(
+            \sprintf('Store name must be dotted lowercase (e.g. "impact.index"), "%s" given.', $name),
+        );
+        $schema >= 1 or throw new \InvalidArgumentException(
+            \sprintf('Store schema version must be >= 1, %d given.', $schema),
+        );
+    }
+}

--- a/core/Common/Store/StoreScope.php
+++ b/core/Common/Store/StoreScope.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store;
+
+/**
+ * Ownership scope of a {@see Store}.
+ *
+ * @api
+ */
+enum StoreScope
+{
+    /**
+     * One document shared by the whole run, independent of which suite is active.
+     */
+    case Application;
+
+    /**
+     * One document per suite. Data written while one suite is active is unreachable from another —
+     * suites may carry different plugin sets and bootstrap, so their persistent state must not leak.
+     */
+    case Suite;
+}

--- a/core/Common/Store/StoreScope.php
+++ b/core/Common/Store/StoreScope.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Testo\Common\Store;
 
+use Testo\Common\Store;
+
 /**
  * Ownership scope of a {@see Store}.
  *

--- a/core/Common/Store/Stores.php
+++ b/core/Common/Store/Stores.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Common\Store;
+
+/**
+ * Registry of stores — the single entry point for opening persistent, cross-run storage.
+ *
+ * Inject this and call {@see open()} with a {@see StoreDefinition}. A suite-scoped definition resolves
+ * against the currently active suite, so it may only be opened while a suite is running.
+ *
+ * This interface is meant to be **consumed, not implemented** by userland code; the framework binds
+ * the implementation.
+ *
+ * @api
+ */
+interface Stores
+{
+    /**
+     * Open the store described by the definition. Cheap — resolves paths, does no I/O until the
+     * returned {@see Store} is read or written.
+     *
+     * @throws \LogicException When a {@see StoreScope::Suite} store is opened outside a suite scope.
+     */
+    public function open(StoreDefinition $definition): Store;
+}

--- a/core/Common/Store/Stores.php
+++ b/core/Common/Store/Stores.php
@@ -21,6 +21,10 @@ interface Stores
      * Open the store described by the definition. Cheap — resolves paths, does no I/O until the
      * returned {@see Store} is read or written.
      *
+     * A {@see StoreScope::Suite} store is bound to the suite that is active at this call: it stays
+     * valid only within that suite. Do not cache it across suites — reopen instead, or the handle
+     * keeps addressing the previous suite's data.
+     *
      * @throws \LogicException When a {@see StoreScope::Suite} store is opened outside a suite scope.
      */
     public function open(StoreDefinition $definition): Store;

--- a/core/Common/Store/Stores.php
+++ b/core/Common/Store/Stores.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Testo\Common\Store;
 
+use Testo\Common\Store;
+
 /**
  * Registry of stores — the single entry point for opening persistent, cross-run storage.
  *

--- a/core/Core/Context/SuiteContext.php
+++ b/core/Core/Context/SuiteContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Core\Context;
+
+/**
+ * Identity of the suite currently being processed, bound into the per-suite container scope.
+ *
+ * Available from discovery onward — before {@see SuiteInfo} exists — so services that must key data
+ * by suite (persistent stores, impact selection) can resolve which suite they are running in without
+ * threading it through every call.
+ *
+ * @api
+ */
+final readonly class SuiteContext
+{
+    /**
+     * @param non-empty-string $name Unique suite name, from {@see \Testo\Application\Config\SuiteConfig::$name}.
+     */
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/tests/Application/Unit/Store/FileStoreTest.php
+++ b/tests/Application/Unit/Store/FileStoreTest.php
@@ -70,13 +70,15 @@ final class FileStoreTest
     {
         $this->inTempDir(function (string $dir): void {
             $fingerprint = $this->mutableContributor();
-            $messenger = $this->messenger();
-            $store = $this->store($dir, fingerprint: [$fingerprint], messenger: $messenger);
-            $store->save(['v' => 1]);
+            $this->store($dir, fingerprint: [$fingerprint])->save(['v' => 1]);
 
+            # The fingerprint is captured once per opened store, so drift is observable only by the
+            # next run — modeled here as a fresh instance over the same file.
             $fingerprint->current = 'changed';
+            $messenger = $this->messenger();
+            $nextRun = $this->store($dir, fingerprint: [$fingerprint], messenger: $messenger);
 
-            Assert::null($store->load());
+            Assert::null($nextRun->load());
             Assert::true($this->warned($messenger, 'fingerprint drift'));
         });
     }
@@ -104,6 +106,63 @@ final class FileStoreTest
 
             Assert::null($store->load());
             Assert::true($this->warned($messenger, 'corrupted'));
+        });
+    }
+
+    #[Test]
+    public function aForeignEnvelopeLayoutReadsAsAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->save(['v' => 1]);
+
+            $this->mutateEnvelope($dir, static fn(array $e): array => ['layout' => 99] + $e);
+
+            Assert::null($store->load());
+        });
+    }
+
+    #[Test]
+    public function anEnvelopeOfAnotherStoreReadsAsAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->save(['v' => 1]);
+
+            $this->mutateEnvelope($dir, static fn(array $e): array => ['name' => 'other.store'] + $e);
+
+            Assert::null($store->load());
+        });
+    }
+
+    #[Test]
+    public function aNonArrayPayloadReadsAsAbsentWithADiagnostic(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $messenger = $this->messenger();
+            $store = $this->store($dir, messenger: $messenger);
+            $store->save(['v' => 1]);
+
+            $this->mutateEnvelope($dir, static fn(array $e): array => ['payload' => 'scalar'] + $e);
+
+            Assert::null($store->load());
+            Assert::true($this->warned($messenger, 'corrupted'));
+        });
+    }
+
+    #[Test]
+    public function aRepeatedProblemIsDiagnosedOnce(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $messenger = $this->messenger();
+            $store = $this->store($dir, messenger: $messenger);
+            $store->save(['v' => 1]);
+            \file_put_contents($this->file($dir), '{not valid json');
+
+            $store->load();
+            $store->load();
+
+            Assert::count($messenger->getMessages()->all(), 1);
         });
     }
 
@@ -138,6 +197,47 @@ final class FileStoreTest
     }
 
     #[Test]
+    public function updateReturningNullLeavesTheStoreUntouched(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->save(['v' => 1]);
+            $before = \file_get_contents($this->file($dir));
+
+            $store->update(static fn(?array $current): ?array => null);
+
+            Assert::same(\file_get_contents($this->file($dir)), $before);
+        });
+    }
+
+    #[Test]
+    public function updateSkipsTheClosureWhenTheLockIsHeld(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $messenger = $this->messenger();
+            $store = $this->store($dir, messenger: $messenger, lockTimeout: 0.05);
+            $store->save(['v' => 1]);
+            $called = false;
+
+            $foreign = \fopen($this->file($dir) . '.lock', 'c');
+            \flock($foreign, \LOCK_EX);
+            try {
+                $store->update(static function () use (&$called): array {
+                    $called = true;
+                    return [];
+                });
+            } finally {
+                \flock($foreign, \LOCK_UN);
+                \fclose($foreign);
+            }
+
+            Assert::false($called);
+            Assert::same($store->load(), ['v' => 1]);
+            Assert::true($this->warned($messenger, 'lock timeout'));
+        });
+    }
+
+    #[Test]
     public function deleteRemovesTheFileAndIsIdempotent(): void
     {
         $this->inTempDir(function (string $dir): void {
@@ -149,6 +249,19 @@ final class FileStoreTest
 
             Assert::null($store->load());
             Assert::false(\is_file($this->file($dir)));
+        });
+    }
+
+    #[Test]
+    public function deleteAlsoRemovesTheLockFile(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->update(static fn(?array $current): array => ['v' => 1]);
+
+            $store->delete();
+
+            Assert::false(\is_file($this->file($dir) . '.lock'));
         });
     }
 
@@ -197,6 +310,7 @@ final class FileStoreTest
         int $schema = 1,
         array $fingerprint = [],
         ?Messenger $messenger = null,
+        float $lockTimeout = 5.0,
     ): FileStore {
         $definition = new StoreDefinition('impact.index', $schema, fingerprint: $fingerprint);
 
@@ -205,12 +319,25 @@ final class FileStoreTest
             Path::create($this->file($base)),
             $definition,
             $messenger ?? $this->messenger(),
+            $lockTimeout,
         );
     }
 
     private function file(string $base): string
     {
         return Path::create($base)->join('app', 'impact.index.json')->__toString();
+    }
+
+    /**
+     * Rewrite a saved envelope with the given transformation — for forging foreign/broken files.
+     *
+     * @param \Closure(array): array $mutate
+     */
+    private function mutateEnvelope(string $base, \Closure $mutate): void
+    {
+        $file = $this->file($base);
+        $envelope = \json_decode((string) \file_get_contents($file), true, flags: \JSON_THROW_ON_ERROR);
+        \file_put_contents($file, \json_encode($mutate($envelope), \JSON_THROW_ON_ERROR));
     }
 
     private function mutableContributor(): FingerprintContributor

--- a/tests/Application/Unit/Store/FileStoreTest.php
+++ b/tests/Application/Unit/Store/FileStoreTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Unit\Store;
+
+use Internal\Path;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Testo\Application\Internal\MessengerHub;
+use Testo\Application\Internal\Store\FileStore;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\Messenger;
+use Testo\Common\Store\FingerprintContributor;
+use Testo\Common\Store\StoreDefinition;
+use Testo\Test;
+
+#[Covers(FileStore::class)]
+final class FileStoreTest
+{
+    #[Test]
+    public function savedPayloadReadsBackUnchanged(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+
+            $store->save(['count' => 3, 'tests' => ['a', 'b']]);
+
+            Assert::same($store->load(), ['count' => 3, 'tests' => ['a', 'b']]);
+        });
+    }
+
+    #[Test]
+    public function loadIsNullWhenNothingWasSaved(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            Assert::null($this->store($dir)->load());
+        });
+    }
+
+    #[Test]
+    public function saveOverwritesThePreviousPayload(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+
+            $store->save(['v' => 1]);
+            $store->save(['v' => 2]);
+
+            Assert::same($store->load(), ['v' => 2]);
+        });
+    }
+
+    #[Test]
+    public function aDifferentSchemaReadsAsAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $messenger = $this->messenger();
+            $this->store($dir, schema: 1)->save(['v' => 1]);
+
+            $store = $this->store($dir, schema: 2, messenger: $messenger);
+
+            Assert::null($store->load());
+            Assert::true($this->warned($messenger, 'schema mismatch'));
+        });
+    }
+
+    #[Test]
+    public function fingerprintDriftReadsAsAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $fingerprint = $this->mutableContributor();
+            $messenger = $this->messenger();
+            $store = $this->store($dir, fingerprint: [$fingerprint], messenger: $messenger);
+            $store->save(['v' => 1]);
+
+            $fingerprint->current = 'changed';
+
+            Assert::null($store->load());
+            Assert::true($this->warned($messenger, 'fingerprint drift'));
+        });
+    }
+
+    #[Test]
+    public function matchingFingerprintStillReads(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir, fingerprint: [$this->mutableContributor()]);
+
+            $store->save(['v' => 1]);
+
+            Assert::same($store->load(), ['v' => 1]);
+        });
+    }
+
+    #[Test]
+    public function corruptedFileReadsAsAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $messenger = $this->messenger();
+            $store = $this->store($dir, messenger: $messenger);
+            $store->save(['v' => 1]);
+            \file_put_contents($this->file($dir), '{not valid json');
+
+            Assert::null($store->load());
+            Assert::true($this->warned($messenger, 'corrupted'));
+        });
+    }
+
+    #[Test]
+    public function updateReceivesCurrentPayloadAndPersistsTheResult(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->save(['hits' => 1]);
+
+            $store->update(static fn(?array $current): array => ['hits' => $current['hits'] + 1]);
+
+            Assert::same($store->load(), ['hits' => 2]);
+        });
+    }
+
+    #[Test]
+    public function updateStartsFromNullWhenAbsent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $seen = 'unset';
+            $store = $this->store($dir);
+
+            $store->update(static function (?array $current) use (&$seen): array {
+                $seen = $current;
+                return ['created' => true];
+            });
+
+            Assert::null($seen);
+            Assert::same($store->load(), ['created' => true]);
+        });
+    }
+
+    #[Test]
+    public function deleteRemovesTheFileAndIsIdempotent(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $store = $this->store($dir);
+            $store->save(['v' => 1]);
+
+            $store->delete();
+            $store->delete();
+
+            Assert::null($store->load());
+            Assert::false(\is_file($this->file($dir)));
+        });
+    }
+
+    #[Test]
+    public function saveLeavesNoTemporaryFilesBehind(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $this->store($dir)->save(['v' => 1]);
+
+            $leftovers = \glob(Path::create($dir)->join('app')->__toString() . '/*.tmp');
+            Assert::same($leftovers, []);
+        });
+    }
+
+    #[Test]
+    public function firstWriteMarksTheBaseDirectorySelfIgnoring(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $this->store($dir)->save(['v' => 1]);
+
+            $gitignore = $dir . '/.gitignore';
+            Assert::true(\is_file($gitignore));
+            Assert::same(\trim((string) \file_get_contents($gitignore)), '*');
+        });
+    }
+
+    #[Test]
+    public function anUnwritableLocationFailsOpenWithoutThrowing(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            # A regular file where the base directory should be: every mkdir underneath must fail.
+            $blocked = $dir . '/blocked';
+            \file_put_contents($blocked, 'x');
+            $messenger = $this->messenger();
+            $store = $this->store($blocked, messenger: $messenger);
+
+            $store->save(['v' => 1]);
+
+            Assert::null($store->load());
+            Assert::true($this->warned($messenger, 'directory unavailable'));
+        });
+    }
+
+    private function store(
+        string $base,
+        int $schema = 1,
+        array $fingerprint = [],
+        ?Messenger $messenger = null,
+    ): FileStore {
+        $definition = new StoreDefinition('impact.index', $schema, fingerprint: $fingerprint);
+
+        return new FileStore(
+            Path::create($base),
+            Path::create($this->file($base)),
+            $definition,
+            $messenger ?? $this->messenger(),
+        );
+    }
+
+    private function file(string $base): string
+    {
+        return Path::create($base)->join('app', 'impact.index.json')->__toString();
+    }
+
+    private function mutableContributor(): FingerprintContributor
+    {
+        return new class implements FingerprintContributor {
+            public string $current = 'v1';
+
+            public function key(): string
+            {
+                return 'fp';
+            }
+
+            public function value(): string
+            {
+                return $this->current;
+            }
+        };
+    }
+
+    private function messenger(): Messenger
+    {
+        return new MessengerHub(new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                return $event;
+            }
+        });
+    }
+
+    private function warned(Messenger $messenger, string $reason): bool
+    {
+        foreach ($messenger->getMessages()->all() as $message) {
+            if (
+                $message->channel === Messenger::CHANNEL_STDERR
+                && \str_contains($message->content, $reason)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \Closure(string): void $test
+     */
+    private function inTempDir(\Closure $test): void
+    {
+        $dir = \sys_get_temp_dir() . '/testo-store-' . \bin2hex(\random_bytes(6));
+        \mkdir($dir, 0777, true);
+
+        try {
+            $test($dir);
+        } finally {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? @\rmdir($item->getPathname()) : @\unlink($item->getPathname());
+        }
+        @\rmdir($dir);
+    }
+}

--- a/tests/Application/Unit/Store/NullStoreTest.php
+++ b/tests/Application/Unit/Store/NullStoreTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Unit\Store;
+
+use Testo\Application\Internal\Store\NullStore;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+#[Test]
+#[Covers(NullStore::class)]
+final class NullStoreTest
+{
+    public function loadIsAlwaysNull(): void
+    {
+        Assert::null((new NullStore())->load());
+    }
+
+    public function saveAndDeleteAreSilentNoOps(): void
+    {
+        $store = new NullStore();
+
+        $store->save(['v' => 1]);
+        $store->delete();
+
+        Assert::null($store->load());
+    }
+
+    public function updateNeverInvokesTheClosure(): void
+    {
+        $called = false;
+
+        (new NullStore())->update(static function () use (&$called): array {
+            $called = true;
+            return [];
+        });
+
+        Assert::false($called);
+    }
+}

--- a/tests/Application/Unit/Store/StoreRegistryTest.php
+++ b/tests/Application/Unit/Store/StoreRegistryTest.php
@@ -76,6 +76,20 @@ final class StoreRegistryTest
     }
 
     #[Test]
+    public function theScopeCheckFiresEvenWhenStoresAreDisabled(): never
+    {
+        $this->inTempDir(function (string $dir): void {
+            # A misplaced open() is a plugin bug; it must not stay hidden on configurations
+            # that happen to have stores turned off.
+            $registry = $this->registry($dir, suite: null, enabled: false);
+
+            Expect::exception(\LogicException::class);
+
+            $registry->open(new StoreDefinition('impact.index', 1, StoreScope::Suite));
+        });
+    }
+
+    #[Test]
     public function disabledSubsystemHandsOutANoDataStore(): void
     {
         $this->inTempDir(function (string $dir): void {

--- a/tests/Application/Unit/Store/StoreRegistryTest.php
+++ b/tests/Application/Unit/Store/StoreRegistryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Unit\Store;
+
+use Internal\Container\ObjectContainer;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Testo\Application\Config\StoreConfig;
+use Testo\Application\Internal\MessengerHub;
+use Testo\Application\Internal\Store\NullStore;
+use Testo\Application\Internal\StoreRegistry;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\Messenger;
+use Testo\Common\Store\StoreDefinition;
+use Testo\Common\Store\StoreScope;
+use Testo\Core\Context\SuiteContext;
+use Testo\Expect;
+use Testo\Test;
+
+#[Covers(StoreRegistry::class)]
+final class StoreRegistryTest
+{
+    #[Test]
+    public function suiteScopedStoreRoundTripsWithinASuite(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $registry = $this->registry($dir, suite: 'Core/Inline');
+            $store = $registry->open(new StoreDefinition('impact.index', 1, StoreScope::Suite));
+
+            $store->save(['selected' => ['a', 'b']]);
+
+            Assert::same($store->load(), ['selected' => ['a', 'b']]);
+        });
+    }
+
+    #[Test]
+    public function applicationScopedStoreRoundTripsWithoutASuite(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $registry = $this->registry($dir, suite: null);
+            $store = $registry->open(new StoreDefinition('timing.durations', 1, StoreScope::Application));
+
+            $store->save(['x' => 1]);
+
+            Assert::same($store->load(), ['x' => 1]);
+        });
+    }
+
+    #[Test]
+    public function oneSuiteCannotSeeAnotherSuitesData(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $container = $this->container('Suite A');
+            $registry = new StoreRegistry($container, new StoreConfig(directory: $dir), $this->messenger());
+            $definition = new StoreDefinition('impact.index', 1, StoreScope::Suite);
+
+            $registry->open($definition)->save(['owner' => 'A']);
+            $container->set(new SuiteContext('Suite B'));
+
+            Assert::null($registry->open($definition)->load());
+        });
+    }
+
+    #[Test]
+    public function openingASuiteStoreOutsideASuiteScopeThrows(): never
+    {
+        $this->inTempDir(function (string $dir): void {
+            $registry = $this->registry($dir, suite: null);
+
+            Expect::exception(\LogicException::class);
+
+            $registry->open(new StoreDefinition('impact.index', 1, StoreScope::Suite));
+        });
+    }
+
+    #[Test]
+    public function disabledSubsystemHandsOutANoDataStore(): void
+    {
+        $this->inTempDir(function (string $dir): void {
+            $registry = $this->registry($dir, suite: 'Core/Inline', enabled: false);
+            $store = $registry->open(new StoreDefinition('impact.index', 1, StoreScope::Suite));
+
+            $store->save(['v' => 1]);
+
+            Assert::instanceOf($store, NullStore::class);
+            Assert::null($store->load());
+            Assert::false(\is_dir($dir . '/suite'));
+        });
+    }
+
+    private function registry(string $dir, ?string $suite, bool $enabled = true): StoreRegistry
+    {
+        return new StoreRegistry(
+            $this->container($suite),
+            new StoreConfig(directory: $dir, enabled: $enabled),
+            $this->messenger(),
+        );
+    }
+
+    private function container(?string $suite): ObjectContainer
+    {
+        $container = new ObjectContainer();
+        $suite === null or $container->set(new SuiteContext($suite));
+
+        return $container;
+    }
+
+    private function messenger(): Messenger
+    {
+        return new MessengerHub(new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                return $event;
+            }
+        });
+    }
+
+    /**
+     * @param \Closure(string): void $test
+     */
+    private function inTempDir(\Closure $test): void
+    {
+        $dir = \sys_get_temp_dir() . '/testo-registry-' . \bin2hex(\random_bytes(6));
+        \mkdir($dir, 0777, true);
+
+        try {
+            $test($dir);
+        } finally {
+            $this->removeDir($dir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? @\rmdir($item->getPathname()) : @\unlink($item->getPathname());
+        }
+        @\rmdir($dir);
+    }
+}

--- a/tests/Common/Unit/Store/FingerprintTest.php
+++ b/tests/Common/Unit/Store/FingerprintTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Common\Unit\Store;
+
+use Internal\Path;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\Store\Fingerprint\Extensions;
+use Testo\Common\Store\Fingerprint\FileHash;
+use Testo\Common\Store\Fingerprint\PhpVersion;
+use Testo\Test;
+
+final class FingerprintTest
+{
+    #[Test]
+    #[Covers(PhpVersion::class)]
+    public function phpVersionIsMajorMinorOnly(): void
+    {
+        $contributor = new PhpVersion();
+
+        Assert::same($contributor->key(), 'php');
+        Assert::same($contributor->value(), \PHP_MAJOR_VERSION . '.' . \PHP_MINOR_VERSION);
+    }
+
+    #[Test]
+    #[Covers(FileHash::class)]
+    public function fileHashReportsAbsenceOfAMissingFile(): void
+    {
+        $contributor = new FileHash(\sys_get_temp_dir() . '/testo-does-not-exist-' . \bin2hex(\random_bytes(6)));
+
+        Assert::same($contributor->value(), 'absent');
+    }
+
+    #[Test]
+    #[Covers(FileHash::class)]
+    public function fileHashChangesWithContentAndKeysOnThePath(): void
+    {
+        $file = \sys_get_temp_dir() . '/testo-filehash-' . \bin2hex(\random_bytes(6));
+        try {
+            \file_put_contents($file, 'one');
+            $contributor = new FileHash($file);
+            $first = $contributor->value();
+
+            \file_put_contents($file, 'two');
+            $second = $contributor->value();
+
+            Assert::same($contributor->key(), (string) Path::create($file));
+            Assert::notSame($first, $second);
+        } finally {
+            @\unlink($file);
+        }
+    }
+
+    #[Test]
+    #[Covers(Extensions::class)]
+    public function extensionsAreOrderInsensitiveAndMarkMissingOnes(): void
+    {
+        $missing = 'testo_missing_ext_' . \bin2hex(\random_bytes(4));
+
+        $a = new Extensions($missing, 'json');
+        $b = new Extensions('json', $missing);
+
+        Assert::same($a->key(), 'ext');
+        Assert::same($a->value(), $b->value());
+        Assert::string($a->value())->contains($missing . ':-');
+    }
+}

--- a/tests/Common/Unit/Store/StoreDefinitionTest.php
+++ b/tests/Common/Unit/Store/StoreDefinitionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Common\Unit\Store;
 
 use Testo\Assert;
 use Testo\Codecov\Covers;
+use Testo\Common\Store\FingerprintContributor;
 use Testo\Common\Store\StoreDefinition;
 use Testo\Common\Store\StoreScope;
 use Testo\Expect;
@@ -34,11 +35,57 @@ final class StoreDefinitionTest
     }
 
     #[Test]
+    public function acceptsDashesInEverySegment(): void
+    {
+        $definition = new StoreDefinition('symfony-console.command-cache', 1);
+
+        Assert::same($definition->name, 'symfony-console.command-cache');
+    }
+
+    #[Test]
     public function rejectsANameThatIsNotDottedLowercase(): never
     {
         Expect::exception(\InvalidArgumentException::class);
 
         new StoreDefinition('Impact_Index', 1);
+    }
+
+    #[Test]
+    public function rejectsADanglingDash(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        new StoreDefinition('retry.flaky-', 1);
+    }
+
+    #[Test]
+    public function rejectsDuplicateFingerprintKeys(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        new StoreDefinition('impact.index', 1, fingerprint: [
+            self::contributor('php'),
+            self::contributor('php'),
+        ]);
+    }
+
+    private static function contributor(string $key): FingerprintContributor
+    {
+        return new class ($key) implements FingerprintContributor {
+            public function __construct(
+                private readonly string $key,
+            ) {}
+
+            public function key(): string
+            {
+                return $this->key;
+            }
+
+            public function value(): string
+            {
+                return 'v';
+            }
+        };
     }
 
     #[Test]

--- a/tests/Common/Unit/Store/StoreDefinitionTest.php
+++ b/tests/Common/Unit/Store/StoreDefinitionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Common\Unit\Store;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\Store\StoreDefinition;
+use Testo\Common\Store\StoreScope;
+use Testo\Expect;
+use Testo\Test;
+
+#[Covers(StoreDefinition::class)]
+final class StoreDefinitionTest
+{
+    #[Test]
+    public function keepsTheGivenValues(): void
+    {
+        $definition = new StoreDefinition('impact.index', 2, StoreScope::Application);
+
+        Assert::same($definition->name, 'impact.index');
+        Assert::same($definition->schema, 2);
+        Assert::same($definition->scope, StoreScope::Application);
+    }
+
+    #[Test]
+    public function defaultsToSuiteScopeWithoutFingerprint(): void
+    {
+        $definition = new StoreDefinition('timing.durations', 1);
+
+        Assert::same($definition->scope, StoreScope::Suite);
+        Assert::same($definition->fingerprint, []);
+    }
+
+    #[Test]
+    public function rejectsANameThatIsNotDottedLowercase(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        new StoreDefinition('Impact_Index', 1);
+    }
+
+    #[Test]
+    public function rejectsAnEmptyName(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        new StoreDefinition('', 1);
+    }
+
+    #[Test]
+    public function rejectsASchemaBelowOne(): never
+    {
+        Expect::exception(\InvalidArgumentException::class);
+
+        new StoreDefinition('impact.index', 0);
+    }
+}


### PR DESCRIPTION
## What was changed

New Store subsystem: named, versioned, scoped documents that survive between runs. Contracts live in `Testo\Common\Store` (`Store`, `Stores`, `StoreDefinition`, `StoreScope`, `FingerprintContributor` with `PhpVersion`/`FileHash`/`Extensions` contributors), the implementation in `Application\Internal` (`StoreRegistry`, `FileStore`, `NullStore`), configured via `StoreConfig` on `ApplicationConfig` (default `.testo/store`, env override `TESTO_STORE_DIR`, `enabled: false` for a no-data mode).

Key properties: per-suite and per-application scopes with suite isolation; invalidation by payload schema version and by an environment fingerprint declared per store; atomic writes (tmp + rename) and flock-guarded `update()`; fail-open on any I/O problem, so a store can never fail a run. `SuiteContext` is now bound into the per-suite container scope before plugins apply, so suite-keyed services can resolve their suite from discovery onward.

See commit history for details.

## Why?

Testo has no state between runs today: every feature that needs memory of past runs (flaky-test history, test durations for scheduling, incremental analysis data) would have to invent its own file format, paths, invalidation and write atomicity. Store gives them one contract for that, with safety rules fixed in one place: deleting the store directory never breaks a run, stale or foreign data reads as absent, disabled stores are indistinguishable from empty ones.

## Checklist

- Tested
  - [ ] Tested manually
  - [x] Unit tests added
- [ ] Documentation