### PR TITLE
fix(output): keep nested runs' terminal output off the --json/--teamcity stdout

### DIFF
--- a/bridge/symfony-console/src/Command/Base.php
+++ b/bridge/symfony-console/src/Command/Base.php
@@ -10,10 +10,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Testo\Application\Application;
 use Testo\Core\Value\Verbosity;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Terminal\Renderer\ColorMode;
 use Yiisoft\Injector\Injector;
 
@@ -82,9 +84,15 @@ abstract class Base extends Command
         );
         $this->container = $this->application->getContainer();
 
+        # The reporters write through ConsoleStreams; build the command's own Symfony output from the
+        # same pair rather than the process streams Symfony wired, so one binding defines where a run's
+        # output goes instead of the bridge reaching for STDOUT independently.
+        $streams = $this->container->get(ConsoleStreams::class);
+        $consoleOutput = new StreamOutput($streams->stdout, $output->getVerbosity(), $output->isDecorated());
+
         $this->container->set($input, InputInterface::class);
-        $this->container->set($output, OutputInterface::class);
-        $this->container->set(new SymfonyStyle($input, $output), StyleInterface::class);
+        $this->container->set($consoleOutput, OutputInterface::class);
+        $this->container->set(new SymfonyStyle($input, $consoleOutput), StyleInterface::class);
         $this->container->set(self::resolveVerbosity($output), Verbosity::class);
         $this->container->set(self::resolveColorMode($input), ColorMode::class);
 

--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -205,30 +205,19 @@ final class Run extends Base
             . 'or use --log-json=<path> to write JSON to a file alongside another renderer.',
         );
 
-        $renderer = match (true) {
-            $teamcity => TeamcityPlugin::class,
-            $json => JsonPlugin::class,
-            default => TerminalPlugin::class,
-        };
-        // Built here, the renderer would capture the console streams before any plugin can rebind them;
-        // deferring it into the run lets a plugin (a test) redirect the reporters first.
-        $deferredRenderer = new class($renderer) implements PluginConfigurator {
-            /** @param class-string<PluginConfigurator> $renderer */
-            public function __construct(private readonly string $renderer) {}
-
-            #[\Override]
-            public function configure(Container $container): void
-            {
-                $container->get($this->renderer)->configure($container);
-            }
-        };
+        $plugins = [
+            match (true) {
+                $teamcity => TeamcityPlugin::class,
+                $json => JsonPlugin::class,
+                default => TerminalPlugin::class,
+            },
+        ];
 
         // --log-json writes the JSON report to a file alongside the stdout renderer above.
         $logJson = $input->getOption('log-json');
-        \is_string($logJson) && $logJson !== ''
-            and (new JsonPlugin($logJson))->configure($this->container);
+        \is_string($logJson) and $logJson !== '' and $plugins[] = (new JsonPlugin($logJson));
 
-        $result = $this->application->run($deferredRenderer);
+        $result = $this->application->run(...$plugins);
 
         return $result->status->isSuccessful()
             ? Command::SUCCESS

--- a/bridge/symfony-console/src/Command/Run.php
+++ b/bridge/symfony-console/src/Command/Run.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Testo\Bridge\Symfony\Console\Command;
 
+use Internal\Container\Container;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Testo\Common\PluginConfigurator;
 use Testo\Output\Html\HtmlPlugin;
 use Testo\Output\Json\JsonPlugin;
 use Testo\Output\Teamcity\TeamcityPlugin;
@@ -208,14 +210,25 @@ final class Run extends Base
             $json => JsonPlugin::class,
             default => TerminalPlugin::class,
         };
-        $this->container->get($renderer)->configure($this->container);
+        // Built here, the renderer would capture the console streams before any plugin can rebind them;
+        // deferring it into the run lets a plugin (a test) redirect the reporters first.
+        $deferredRenderer = new class($renderer) implements PluginConfigurator {
+            /** @param class-string<PluginConfigurator> $renderer */
+            public function __construct(private readonly string $renderer) {}
+
+            #[\Override]
+            public function configure(Container $container): void
+            {
+                $container->get($this->renderer)->configure($container);
+            }
+        };
 
         // --log-json writes the JSON report to a file alongside the stdout renderer above.
         $logJson = $input->getOption('log-json');
         \is_string($logJson) && $logJson !== ''
             and (new JsonPlugin($logJson))->configure($this->container);
 
-        $result = $this->application->run();
+        $result = $this->application->run($deferredRenderer);
 
         return $result->status->isSuccessful()
             ? Command::SUCCESS

--- a/bridge/symfony-console/tests/Acceptance/RunCommandTest.php
+++ b/bridge/symfony-console/tests/Acceptance/RunCommandTest.php
@@ -126,6 +126,7 @@ final class RunCommandTest
             use Testo\\Application\\Config\\Plugin\\ApplicationPlugins;
             use Testo\\Application\\Config\\SuiteConfig;
             use Testo\\Output\\Html\\HtmlPlugin;
+            use Tests\\Bridge\\SymfonyConsole\\Stub\\DiscardConsoleStreams;
 
             return new ApplicationConfig(
                 src: [],
@@ -135,7 +136,8 @@ final class RunCommandTest
                         location: new FinderConfig(include: [{$stub}]),
                     ),
                 ],
-                plugins: ApplicationPlugins::without(HtmlPlugin::class)->with(HtmlPlugin::inert()),
+                plugins: ApplicationPlugins::without(HtmlPlugin::class)
+                    ->with(HtmlPlugin::inert(), new DiscardConsoleStreams()),
             );
             PHP;
     }

--- a/bridge/symfony-console/tests/Acceptance/StdoutLeakTest.php
+++ b/bridge/symfony-console/tests/Acceptance/StdoutLeakTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\SymfonyConsole\Acceptance;
+
+use Testo\Assert;
+use Testo\Bridge\Symfony\Console\Command\Run;
+use Testo\Codecov\Covers;
+use Testo\Test;
+
+/**
+ * Under `--json` the report must be the only thing on stdout — a machine consumer parses the whole
+ * stream. The acceptance tests spawn a nested `run` in-process per case; a reporter of one that wrote
+ * to the real STDOUT instead of the rebound {@see \Testo\Output\ConsoleStreams} would prepend its
+ * terminal verse to that stream. Nothing in-process can catch this: the write goes straight to the
+ * process fd, past the CommandTester buffer. So this drives the real binary as a subprocess and reads
+ * its actual stdout.
+ */
+#[Test]
+#[Covers(Run::class)]
+final class StdoutLeakTest
+{
+    public function jsonStdoutCarriesOnlyTheReport(): void
+    {
+        [$stdout, $stderr] = self::runBinary(
+            '--json',
+            '--suite=Bridge/SymfonyConsole/Acceptance',
+            '--filter=RunCommandTest',
+        );
+
+        $report = \json_decode(\trim($stdout), true);
+
+        Assert::true(
+            $report !== null,
+            "stdout must be a single JSON object; a nested run leaked terminal output before it:\n"
+            . \substr($stdout, 0, 600)
+            . "\n--- stderr ---\n" . \substr($stderr, 0, 600),
+        );
+        Assert::true(
+            \is_array($report) && isset($report['status']),
+            'stdout JSON must be the run report (carrying a "status")',
+        );
+    }
+
+    /**
+     * Runs the real `testo` binary from the repository root and returns [stdout, stderr].
+     *
+     * @return array{string, string}
+     */
+    private static function runBinary(string ...$args): array
+    {
+        $root = \dirname(__DIR__, 4);
+        $command = [\PHP_BINARY, $root . '/vendor/bin/testo', ...$args];
+
+        $process = \proc_open(
+            $command,
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $root,
+        );
+        \assert(\is_resource($process));
+        \fclose($pipes[0]);
+
+        $stdout = (string) \stream_get_contents($pipes[1]);
+        $stderr = (string) \stream_get_contents($pipes[2]);
+        \fclose($pipes[1]);
+        \fclose($pipes[2]);
+        \proc_close($process);
+
+        return [$stdout, $stderr];
+    }
+}

--- a/bridge/symfony-console/tests/Stub/DiscardConsoleStreams.php
+++ b/bridge/symfony-console/tests/Stub/DiscardConsoleStreams.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Bridge\SymfonyConsole\Stub;
+
+use Internal\Container\Container;
+use Testo\Common\PluginConfigurator;
+use Testo\Output\ConsoleStreams;
+
+/**
+ * Points the reporters at a discard stream, so a nested in-process run's terminal rendering stays off
+ * the outer run's real stdout.
+ */
+final class DiscardConsoleStreams implements PluginConfigurator
+{
+    #[\Override]
+    public function configure(Container $container): void
+    {
+        $sink = \fopen('php://temp', 'w+b');
+        \assert($sink !== false);
+        $container->set(new ConsoleStreams($sink, $sink), ConsoleStreams::class);
+    }
+}

--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -95,17 +95,18 @@ final readonly class Application
     }
 
     /**
-     * @param PluginConfigurator ...$latePlugins Applied after the configured application plugins, so a
-     *        binding one of them made — the reporter streams, say — is already in place before these run.
+     * @param PluginConfigurator|class-string<PluginConfigurator> ...$latePlugins Applied after the configured
+     *        application plugins, so a binding one of them made — the reporter streams, say — is already in
+     *        place before these run.
      */
-    public function run(PluginConfigurator ...$latePlugins): RunResult
+    public function run(PluginConfigurator|string ...$latePlugins): RunResult
     {
         return $this->container->scope(static function (Container $container) use ($latePlugins): RunResult {
             $startedAt = \microtime(true);
 
             $appConfig = $container->get(ApplicationConfig::class);
             self::applyPlugins($container, self::resolvePlugins($appConfig->plugins, ApplicationPlugins::class));
-            /** @var list<PluginConfigurator> $latePlugins */
+            /** @var list<PluginConfigurator|class-string<PluginConfigurator>> $latePlugins */
             self::applyPlugins($container, $latePlugins);
             $filter = $container->get(Filter::class);
 
@@ -216,11 +217,15 @@ final readonly class Application
     /**
      * Apply plugin services to the container.
      *
-     * @param list<PluginConfigurator> $plugins
+     * @param list<PluginConfigurator|class-string<PluginConfigurator>> $plugins
      */
     private static function applyPlugins(Container $container, array $plugins): void
     {
         foreach ($plugins as $plugin) {
+            if (\is_string($plugin)) {
+                $plugin = $container->get($plugin);
+            }
+
             $plugin->configure($container);
         }
     }

--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -94,13 +94,19 @@ final readonly class Application
         return new self($container);
     }
 
-    public function run(): RunResult
+    /**
+     * @param PluginConfigurator ...$latePlugins Applied after the configured application plugins, so a
+     *        binding one of them made — the reporter streams, say — is already in place before these run.
+     */
+    public function run(PluginConfigurator ...$latePlugins): RunResult
     {
-        return $this->container->scope(static function (Container $container): RunResult {
+        return $this->container->scope(static function (Container $container) use ($latePlugins): RunResult {
             $startedAt = \microtime(true);
 
             $appConfig = $container->get(ApplicationConfig::class);
             self::applyPlugins($container, self::resolvePlugins($appConfig->plugins, ApplicationPlugins::class));
+            /** @var list<PluginConfigurator> $latePlugins */
+            self::applyPlugins($container, $latePlugins);
             $filter = $container->get(Filter::class);
 
             $dispatcher = $container->get(EventDispatcherInterface::class);

--- a/core/Application/Application.php
+++ b/core/Application/Application.php
@@ -222,9 +222,7 @@ final readonly class Application
     private static function applyPlugins(Container $container, array $plugins): void
     {
         foreach ($plugins as $plugin) {
-            if (\is_string($plugin)) {
-                $plugin = $container->get($plugin);
-            }
+            \is_string($plugin) and $plugin = $container->get($plugin);
 
             $plugin->configure($container);
         }

--- a/core/Application/Config/DefaultServicesConfig.php
+++ b/core/Application/Config/DefaultServicesConfig.php
@@ -85,7 +85,7 @@ final readonly class DefaultServicesConfig implements PluginConfigurator
                 $c->get(ConsoleStreams::class)->stdout,
             ),
             JsonPlugin::class => static fn(Container $c): JsonPlugin => new JsonPlugin(
-                stream: $c->get(ConsoleStreams::class)->stdout,
+                $c->get(ConsoleStreams::class)->stdout,
             ),
         ];
     }

--- a/core/Application/Config/DefaultServicesConfig.php
+++ b/core/Application/Config/DefaultServicesConfig.php
@@ -9,13 +9,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Testo\Application\Internal\EventDispatcher;
 use Testo\Application\Internal\MessengerHub;
-use Testo\Core\Value\Verbosity;
-use Testo\Output\ConsoleStreams;
-use Testo\Output\Json\JsonPlugin;
-use Testo\Output\Teamcity\TeamcityPlugin;
-use Testo\Output\Terminal\Renderer\ColorMode;
-use Testo\Output\Terminal\Renderer\TerminalLogger;
-use Testo\Output\Terminal\TerminalPlugin;
 use Testo\Pipeline\Internal\OutputInterceptor;
 use Testo\Common\EventListenerCollector;
 use Testo\Common\Messenger;
@@ -69,24 +62,6 @@ final readonly class DefaultServicesConfig implements PluginConfigurator
             EventListenerCollector::class => EventDispatcher::class,
             InterceptorCollector::class => InterceptorProvider::class,
             Messenger::class => MessengerHub::class,
-
-            ConsoleStreams::class => static fn(): ConsoleStreams => new ConsoleStreams(),
-
-            TerminalPlugin::class => static fn(Container $c): TerminalPlugin => new TerminalPlugin(
-                new TerminalLogger(
-                    verbosity: $c->has(Verbosity::class) ? $c->get(Verbosity::class) : Verbosity::Normal,
-                    output: $c->get(ConsoleStreams::class)->stdout,
-                    errorOutput: $c->get(ConsoleStreams::class)->stderr,
-                ),
-                $c->has(ColorMode::class) ? $c->get(ColorMode::class) : ColorMode::Always,
-            ),
-            TeamcityPlugin::class => static fn(Container $c): TeamcityPlugin => new TeamcityPlugin(
-                $c->has(ColorMode::class) ? $c->get(ColorMode::class) : ColorMode::Always,
-                $c->get(ConsoleStreams::class)->stdout,
-            ),
-            JsonPlugin::class => static fn(Container $c): JsonPlugin => new JsonPlugin(
-                $c->get(ConsoleStreams::class)->stdout,
-            ),
         ];
     }
 

--- a/core/Application/Config/DefaultServicesConfig.php
+++ b/core/Application/Config/DefaultServicesConfig.php
@@ -9,6 +9,13 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Testo\Application\Internal\EventDispatcher;
 use Testo\Application\Internal\MessengerHub;
+use Testo\Core\Value\Verbosity;
+use Testo\Output\ConsoleStreams;
+use Testo\Output\Json\JsonPlugin;
+use Testo\Output\Teamcity\TeamcityPlugin;
+use Testo\Output\Terminal\Renderer\ColorMode;
+use Testo\Output\Terminal\Renderer\TerminalLogger;
+use Testo\Output\Terminal\TerminalPlugin;
 use Testo\Pipeline\Internal\OutputInterceptor;
 use Testo\Common\EventListenerCollector;
 use Testo\Common\Messenger;
@@ -62,6 +69,24 @@ final readonly class DefaultServicesConfig implements PluginConfigurator
             EventListenerCollector::class => EventDispatcher::class,
             InterceptorCollector::class => InterceptorProvider::class,
             Messenger::class => MessengerHub::class,
+
+            ConsoleStreams::class => static fn(): ConsoleStreams => new ConsoleStreams(),
+
+            TerminalPlugin::class => static fn(Container $c): TerminalPlugin => new TerminalPlugin(
+                new TerminalLogger(
+                    verbosity: $c->has(Verbosity::class) ? $c->get(Verbosity::class) : Verbosity::Normal,
+                    output: $c->get(ConsoleStreams::class)->stdout,
+                    errorOutput: $c->get(ConsoleStreams::class)->stderr,
+                ),
+                $c->has(ColorMode::class) ? $c->get(ColorMode::class) : ColorMode::Always,
+            ),
+            TeamcityPlugin::class => static fn(Container $c): TeamcityPlugin => new TeamcityPlugin(
+                $c->has(ColorMode::class) ? $c->get(ColorMode::class) : ColorMode::Always,
+                $c->get(ConsoleStreams::class)->stdout,
+            ),
+            JsonPlugin::class => static fn(Container $c): JsonPlugin => new JsonPlugin(
+                stream: $c->get(ConsoleStreams::class)->stdout,
+            ),
         ];
     }
 

--- a/core/Application/Config/Internal/ConfigInflector.php
+++ b/core/Application/Config/Internal/ConfigInflector.php
@@ -185,7 +185,7 @@ final class ConfigInflector implements Inflector
      */
     private function getXPath(XPath $attribute): mixed
     {
-        $value = $this->xml?->xpath($attribute->path);
+        $value = $this->xpath($attribute->path);
 
         return \is_array($value) && \array_key_exists($attribute->key, $value)
             ? $value[$attribute->key]
@@ -201,7 +201,7 @@ final class ConfigInflector implements Inflector
             return null;
         }
 
-        $value = $this->xml->xpath($attribute->path);
+        $value = $this->xpath($attribute->path);
         if (!\is_array($value) || empty($value)) {
             return null;
         }
@@ -225,7 +225,7 @@ final class ConfigInflector implements Inflector
         }
 
         $result = [];
-        $value = $this->xml->xpath($attribute->path);
+        $value = $this->xpath($attribute->path);
         \is_array($value) or throw new \Exception(\sprintf('Invalid XPath `%s`', $attribute->path));
 
         foreach ($value as $xml) {
@@ -237,6 +237,29 @@ final class ConfigInflector implements Inflector
         }
 
         return $result;
+    }
+
+    /**
+     * Runs an XPath query with libxml's parse diagnostics suppressed: an invalid expression is a
+     * config-author mistake the callers already handle, and the raw PHP warning it would otherwise
+     * raise is noise on the `--json` / `--teamcity` report a consumer parses.
+     *
+     * @return array<array-key, \SimpleXMLElement>|false|null `null` when no XML is configured, `false`
+     *         on an invalid expression, otherwise the (possibly empty) match list.
+     */
+    private function xpath(string $path): array|false|null
+    {
+        if ($this->xml === null) {
+            return null;
+        }
+
+        $previous = \libxml_use_internal_errors(true);
+        try {
+            return $this->xml->xpath($path);
+        } finally {
+            \libxml_clear_errors();
+            \libxml_use_internal_errors($previous);
+        }
     }
 
     /**

--- a/core/Output/ConsoleStreams.php
+++ b/core/Output/ConsoleStreams.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Testo\Output;
+
+/**
+ * The process's stdout/stderr as an injectable pair of streams.
+ *
+ * Reporters write through this rather than the {@see \STDOUT} / {@see \STDERR} constants, so binding a
+ * different pair points a run somewhere the constants cannot reach — a memory stream, a discard stream.
+ *
+ * @api
+ */
+final readonly class ConsoleStreams
+{
+    /** @var resource */
+    public mixed $stdout;
+
+    /** @var resource */
+    public mixed $stderr;
+
+    /**
+     * @param resource|null $stdout Defaults to {@see \STDOUT}.
+     * @param resource|null $stderr Defaults to {@see \STDERR}.
+     */
+    public function __construct($stdout = null, $stderr = null)
+    {
+        $this->stdout = $stdout ?? \STDOUT;
+        $this->stderr = $stderr ?? \STDERR;
+    }
+}

--- a/core/Output/Json/JsonPlugin.php
+++ b/core/Output/Json/JsonPlugin.php
@@ -14,6 +14,7 @@ use Testo\Event\Framework\SessionFinished;
 use Testo\Event\Framework\SessionStarting;
 use Testo\Event\Report\ReportFileGenerated;
 use Testo\Event\Report\ReportFileGenerating;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Json\Internal\JsonReport;
 
 /**
@@ -68,6 +69,8 @@ final class JsonPlugin implements PluginConfigurator
     #[\Override]
     public function configure(Container $container): void
     {
+        $this->path === null and $this->stream ??= $container->get(ConsoleStreams::class)->stdout;
+
         $listeners = $container->get(EventListenerCollector::class);
         $listeners->addListener(SessionFinished::class, $this->onSessionFinished(...));
 

--- a/core/Output/Json/JsonPlugin.php
+++ b/core/Output/Json/JsonPlugin.php
@@ -46,19 +46,22 @@ final class JsonPlugin implements PluginConfigurator
      */
     private readonly ?Path $path;
 
+    /** @var resource|null Stdout-mode stream, or null for {@see \STDOUT}. */
+    private $stream;
+
     private readonly JsonReport $report;
 
     /**
-     * @param string|null $outputPath When set to a non-empty path, the report is written to that
-     *        file and the active stdout renderer is left untouched (`--log-json` / file mode). When
-     *        null or an empty string, the report is written to {@see $stream} (`--json` / stdout
-     *        mode) — empty is normalized to null, matching {@see \Testo\Output\JUnit\JUnitPlugin}.
-     * @param resource|null $stream Stream for stdout mode; defaults to {@see \STDOUT}. Ignored
-     *        when a file path is set.
+     * @param string|resource|null $output Where the report goes. A non-empty string path writes the
+     *        report to that file and leaves the active stdout renderer untouched (`--log-json` / file
+     *        mode); a stream resource writes the report as the stdout output (`--json` / stdout mode);
+     *        null defaults to {@see \STDOUT}. An empty string is stdout mode too, matching
+     *        {@see \Testo\Output\JUnit\JUnitPlugin}.
      */
-    public function __construct(?string $outputPath = null, private $stream = null)
+    public function __construct($output = null)
     {
-        $this->path = $outputPath !== null && $outputPath !== '' ? Path::create($outputPath) : null;
+        $this->path = \is_string($output) && $output !== '' ? Path::create($output) : null;
+        $this->stream = \is_resource($output) ? $output : null;
         $this->report = new JsonReport();
     }
 

--- a/core/Output/Teamcity/Teamcity/TeamcityLogger.php
+++ b/core/Output/Teamcity/Teamcity/TeamcityLogger.php
@@ -19,6 +19,7 @@ use Testo\Core\Context\TestResult;
 use Testo\Core\Log\Message;
 use Testo\Core\Value\Status;
 use Testo\Core\Report\ReportInfo;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Rendering\BenchMapper;
 use Testo\Output\Rendering\StackTrace;
 use Testo\Output\Terminal\Renderer\Style;
@@ -43,11 +44,11 @@ final class TeamcityLogger
     private $output;
 
     /**
-     * @param resource|null $output Stream the logger writes to; defaults to {@see \STDOUT}.
+     * @param ConsoleStreams $streams Source of the stdout stream service messages are written to.
      */
-    public function __construct($output = null)
+    public function __construct(ConsoleStreams $streams)
     {
-        $this->output = $output ?? \STDOUT;
+        $this->output = $streams->stdout;
     }
 
     /**

--- a/core/Output/Teamcity/TeamcityPlugin.php
+++ b/core/Output/Teamcity/TeamcityPlugin.php
@@ -19,6 +19,7 @@ use Testo\Event\Test\TestDataSetFinished;
 use Testo\Event\Test\TestDataSetStarting;
 use Testo\Event\Test\TestPipelineFinished;
 use Testo\Event\Test\TestPipelineStarting;
+use Testo\Event\Test\TestStarting;
 use Testo\Event\TestCase\TestCaseFinished;
 use Testo\Event\TestCase\TestCaseStarting;
 use Testo\Event\TestSuite\TestSuiteFinished;
@@ -50,9 +51,9 @@ final class TeamcityPlugin implements PluginConfigurator
 
     /**
      * Regular (non-DataProvider) tests whose `testStarted` has not been emitted yet, per test id. Emitted
-     * lazily on the first message (so output streams in real time), or at pipeline finish if the test
-     * produced no output. Dropped once `testStarted` has been emitted (or for data sets, which emit it
-     * eagerly).
+     * when the test body is about to run ({@see onTestStarting}); the message stream and pipeline finish
+     * emit it as a fallback for a test aborted before its body ran. Dropped once `testStarted` has been
+     * emitted (or for data sets, which emit it eagerly).
      *
      * @var array<int, TestInfo>
      */
@@ -60,13 +61,16 @@ final class TeamcityPlugin implements PluginConfigurator
 
     private readonly TeamcityLogger $logger;
 
-    public function __construct(ColorMode $colorMode = ColorMode::Always)
+    /**
+     * @param resource|null $output Stream service messages are written to; defaults to {@see \STDOUT}.
+     */
+    public function __construct(ColorMode $colorMode = ColorMode::Always, $output = null)
     {
         // Service messages are parsed by the CI server, but the human-readable lines around them go
         // through the same styling as the terminal renderer's — so the color decision has to be made
         // here too, or `--no-ansi` would leave ANSI in a machine-read stream.
         Style::setColorsEnabled($colorMode->shouldUseColors());
-        $this->logger = new TeamcityLogger();
+        $this->logger = new TeamcityLogger($output);
     }
 
     #[\Override]
@@ -87,6 +91,10 @@ final class TeamcityPlugin implements PluginConfigurator
         // Test Pipeline events (lifecycle of entire test through all interceptors)
         $listeners->addListener(TestPipelineStarting::class, $this->onTestPipelineStarting(...));
         $listeners->addListener(TestPipelineFinished::class, $this->onTestPipelineFinished(...));
+
+        // Fires from the pipeline core right before the test body runs — the earliest point at which a
+        // regular test is known not to be a DataProvider batch, so testStarted can be emitted eagerly.
+        $listeners->addListener(TestStarting::class, $this->onTestStarting(...));
 
         // Test Batch events (for DataProvider)
         $listeners->addListener(TestBatchStarting::class, $this->onTestBatchStarting(...));
@@ -145,7 +153,7 @@ final class TeamcityPlugin implements PluginConfigurator
 
         $id = $identity->pipelineId;
 
-        // Lazily emit testStarted for a regular test on its first output, so it streams in real time.
+        // Fallback: if the test body never ran (no TestStarting), emit testStarted before its output.
         if (isset($this->pendingStart[$id])) {
             $this->logger->testStartedFromInfo($this->pendingStart[$id]);
             unset($this->pendingStart[$id]);
@@ -156,11 +164,32 @@ final class TeamcityPlugin implements PluginConfigurator
 
     private function onTestPipelineStarting(TestPipelineStarting $event): void
     {
-        // Assume a regular test: attribute output to it and keep testStarted pending until output
-        // arrives. If it turns out to be a DataProvider batch, onTestBatchStarting clears this.
+        // Assume a regular test: attribute output to it and keep testStarted pending until its body
+        // starts (onTestStarting). If it turns out to be a DataProvider batch, onTestBatchStarting
+        // clears this.
         $id = $event->testInfo->identity->pipelineId;
         $this->currentName[$id] = $event->testInfo->name;
         $this->pendingStart[$id] = $event->testInfo;
+    }
+
+    private function onTestStarting(TestStarting $event): void
+    {
+        $id = $event->testInfo->identity->pipelineId;
+
+        // A data set emits its own testStarted eagerly (onTestDataSetStarting) and the batch around it
+        // is a suite, not a test — so inside a batch there is nothing to start here. A data set shares
+        // its batch's pipelineId, so this flag is already set by the time its body runs.
+        if (isset($this->isBatch[$id])) {
+            return;
+        }
+
+        // Regular test: emit testStarted the moment its body is about to run, so the IDE shows a running
+        // spinner for the whole execution. The pendingStart guard also makes a retried test — which
+        // fires TestStarting again — emit testStarted only once.
+        if (isset($this->pendingStart[$id])) {
+            $this->logger->testStartedFromInfo($this->pendingStart[$id]);
+            unset($this->pendingStart[$id]);
+        }
     }
 
     private function onTestPipelineFinished(TestPipelineFinished $event): void
@@ -174,7 +203,8 @@ final class TeamcityPlugin implements PluginConfigurator
             return;
         }
 
-        // Regular test: testStarted was emitted lazily on first output; if there was none, emit now.
+        // Regular test: testStarted is normally emitted when the body starts; if the body never ran
+        // (aborted in an interceptor before TestStarting), emit it now so the node still appears.
         if (isset($this->pendingStart[$id])) {
             $this->logger->testStartedFromInfo($this->pendingStart[$id]);
             unset($this->pendingStart[$id]);

--- a/core/Output/Teamcity/TeamcityPlugin.php
+++ b/core/Output/Teamcity/TeamcityPlugin.php
@@ -59,23 +59,24 @@ final class TeamcityPlugin implements PluginConfigurator
      */
     private array $pendingStart = [];
 
-    private readonly TeamcityLogger $logger;
+    private ?TeamcityLogger $logger = null;
 
-    /**
-     * @param resource|null $output Stream service messages are written to; defaults to {@see \STDOUT}.
-     */
-    public function __construct(ColorMode $colorMode = ColorMode::Always, $output = null)
-    {
-        // Service messages are parsed by the CI server, but the human-readable lines around them go
-        // through the same styling as the terminal renderer's — so the color decision has to be made
-        // here too, or `--no-ansi` would leave ANSI in a machine-read stream.
-        Style::setColorsEnabled($colorMode->shouldUseColors());
-        $this->logger = new TeamcityLogger($output);
-    }
+    public function __construct(
+        private readonly ?ColorMode $colorMode = null,
+    ) {}
 
     #[\Override]
     public function configure(Container $container): void
     {
+        // Service messages are parsed by the CI server, but the human-readable lines around them go
+        // through the same styling as the terminal renderer's — so the color decision has to be made
+        // here too, or `--no-ansi` would leave ANSI in a machine-read stream.
+        $colorMode = $this->colorMode
+            ?? ($container->has(ColorMode::class) ? $container->get(ColorMode::class) : ColorMode::Always);
+        Style::setColorsEnabled($colorMode->shouldUseColors());
+
+        $this->logger = $container->get(TeamcityLogger::class);
+
         $listeners = $container->get(EventListenerCollector::class);
 
         // Framework events

--- a/core/Output/Terminal/Renderer/TerminalLogger.php
+++ b/core/Output/Terminal/Renderer/TerminalLogger.php
@@ -20,6 +20,7 @@ use Testo\Core\Value\Status;
 use Testo\Core\Value\Verbosity;
 use Testo\Data\MultipleResult;
 use Testo\Core\Report\ReportInfo;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Rendering\ChannelRenderer;
 use Testo\Output\Rendering\SharedStream;
 
@@ -81,21 +82,19 @@ final class TerminalLogger
     private ?ChannelRenderer $unownedChannels = null;
 
     /**
-     * @param resource|null $output Stream for the human-facing report; defaults to {@see \STDOUT}.
-     *        Output goes straight to the stream, bypassing PHP output buffering, so it is not captured
-     *        by the messenger's output interceptor.
-     * @param resource|null $errorOutput Stream for the internal {@see Messenger::CHANNEL_STDERR}
-     *        channel (framework faults); defaults to {@see \STDERR} so those messages never corrupt
-     *        the structured report on {@see \STDOUT} (which `--json` / `--teamcity` and CI parse).
+     * @param ConsoleStreams $streams Streams the report and framework-fault channels go to. The report
+     *        writes straight to the stdout stream, bypassing PHP output buffering, so it is not captured
+     *        by the messenger's output interceptor. {@see Messenger::CHANNEL_STDERR} (framework faults)
+     *        goes to the stderr stream so those messages never corrupt the structured report the stdout
+     *        stream carries.
      */
     public function __construct(
+        ConsoleStreams $streams,
         private readonly OutputFormat $format = OutputFormat::Compact,
         private readonly Verbosity $verbosity = Verbosity::Normal,
-        $output = null,
-        $errorOutput = null,
     ) {
-        $this->out = new SharedStream($output ?? \STDOUT);
-        $this->errorOutput = $errorOutput ?? \STDERR;
+        $this->out = new SharedStream($streams->stdout);
+        $this->errorOutput = $streams->stderr;
     }
 
     /**

--- a/core/Output/Terminal/TerminalPlugin.php
+++ b/core/Output/Terminal/TerminalPlugin.php
@@ -42,17 +42,21 @@ final class TerminalPlugin implements PluginConfigurator
      */
     private array $isBatch = [];
 
+    private ?TerminalLogger $logger = null;
+
     public function __construct(
-        private readonly TerminalLogger $logger,
-        ColorMode $colorMode = ColorMode::Always,
-    ) {
-        // Configure color support based on mode
-        Style::setColorsEnabled($colorMode->shouldUseColors());
-    }
+        private readonly ?ColorMode $colorMode = null,
+    ) {}
 
     #[\Override]
     public function configure(Container $container): void
     {
+        $colorMode = $this->colorMode
+            ?? ($container->has(ColorMode::class) ? $container->get(ColorMode::class) : ColorMode::Always);
+        Style::setColorsEnabled($colorMode->shouldUseColors());
+
+        $this->logger = $container->get(TerminalLogger::class);
+
         $listeners = $container->get(EventListenerCollector::class);
 
         // Framework events

--- a/core/Testing/Helper/TestRunner.php
+++ b/core/Testing/Helper/TestRunner.php
@@ -74,6 +74,7 @@ final class TestRunner
         );
 
         $suiteConfigs === [] and throw new \RuntimeException('Testing Suite is not configured.');
+        /** @var TestingSuite $config */
         $config = \reset($suiteConfigs)->newInstance();
 
         # Extra plugins requested by the test, on top of the suite defaults.

--- a/core/Testing/Helper/TestRunner.php
+++ b/core/Testing/Helper/TestRunner.php
@@ -13,6 +13,7 @@ use Testo\Application\Config\SuiteConfig;
 use Testo\Common\PluginConfigurator;
 use Testo\Common\Reflection;
 use Testo\Core\Context\TestResult;
+use Testo\Output\ConsoleStreams;
 use Testo\Testing\Attribute\TestingSuite;
 
 /**
@@ -119,6 +120,12 @@ final class TestRunner
             ),
             ApplicationConfig::class,
         );
+
+        # A TestRunner run is read through its results, never its terminal output — so a reporter it
+        # activates must not reach the real process streams. Default the seam to memory.
+        $sink = \fopen('php://memory', 'w+b');
+        \assert($sink !== false);
+        $app->getContainer()->set(new ConsoleStreams($sink, $sink), ConsoleStreams::class);
 
         return $app;
     }

--- a/tests/Core/Testing/Feature/ReporterIsolationFeatureTest.php
+++ b/tests/Core/Testing/Feature/ReporterIsolationFeatureTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Feature;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Core\Value\Status;
+use Testo\Output\Terminal\TerminalPlugin;
+use Testo\Test;
+use Testo\Testing\Attribute\TestingSuite;
+use Testo\Testing\Helper\TestRunner;
+use Tests\Core\Testing\Stub\ReporterStub;
+
+/**
+ * A {@see TestRunner} run activates a terminal reporter (as a future `--json` on `runTest` would), and
+ * its render must land on the run's own {@see \Testo\Output\ConsoleStreams} — a memory pair by default —
+ * never the real process stdout. {@see TestingStdoutLeakTest} drives this under `--json` in a subprocess
+ * to prove the machine report stays clean; this in-process check only confirms the run still passes.
+ */
+#[Test]
+#[Covers(TestRunner::class)]
+#[TestingSuite(
+    path: __DIR__ . '/../Stub/ReporterStub.php',
+    plugins: [TerminalPlugin::class],
+)]
+final class ReporterIsolationFeatureTest
+{
+    public function reporterRunPassesWithoutTouchingRealStdout(): void
+    {
+        $result = TestRunner::runTest([ReporterStub::class, 'passes']);
+
+        Assert::same($result->status, Status::Passed);
+    }
+}

--- a/tests/Core/Testing/Feature/TestingStdoutLeakTest.php
+++ b/tests/Core/Testing/Feature/TestingStdoutLeakTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Feature;
+
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Test;
+use Testo\Testing\Helper\TestRunner;
+
+/**
+ * Under `--json` the report must be the only thing on stdout — a machine consumer parses the whole
+ * stream. A {@see TestRunner} run activates its own reporters (see {@see ReporterIsolationFeatureTest});
+ * one that wrote to the real STDOUT instead of the run's {@see \Testo\Output\ConsoleStreams} would
+ * prepend its render to that stream. Nothing in-process can catch this: the write goes straight to the
+ * process fd, past any output buffer. So this drives the real binary as a subprocess and reads its
+ * actual stdout.
+ */
+#[Test]
+#[Covers(TestRunner::class)]
+final class TestingStdoutLeakTest
+{
+    public function jsonStdoutCarriesOnlyTheReport(): void
+    {
+        [$stdout, $stderr] = self::runBinary(
+            '--json',
+            '--suite=Core/Testing/Feature',
+            '--filter=ReporterIsolationFeatureTest',
+        );
+
+        $report = \json_decode(\trim($stdout), true);
+
+        Assert::true(
+            $report !== null,
+            "stdout must be a single JSON object; a TestRunner reporter leaked its render before it:\n"
+            . \substr($stdout, 0, 600)
+            . "\n--- stderr ---\n" . \substr($stderr, 0, 600),
+        );
+        Assert::true(
+            \is_array($report) && isset($report['status']),
+            'stdout JSON must be the run report (carrying a "status")',
+        );
+    }
+
+    /**
+     * Runs the real `testo` binary from the repository root and returns [stdout, stderr].
+     *
+     * @return array{string, string}
+     */
+    private static function runBinary(string ...$args): array
+    {
+        $root = \dirname(__DIR__, 4);
+        $command = [\PHP_BINARY, $root . '/vendor/bin/testo', ...$args];
+
+        $process = \proc_open(
+            $command,
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $root,
+        );
+        \assert(\is_resource($process));
+        \fclose($pipes[0]);
+
+        $stdout = (string) \stream_get_contents($pipes[1]);
+        $stderr = (string) \stream_get_contents($pipes[2]);
+        \fclose($pipes[1]);
+        \fclose($pipes[2]);
+        \proc_close($process);
+
+        return [$stdout, $stderr];
+    }
+}

--- a/tests/Core/Testing/Stub/ReporterStub.php
+++ b/tests/Core/Testing/Stub/ReporterStub.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Testing\Stub;
+
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Passing stub driven through the pipeline by {@see \Testo\Testing\Helper\TestRunner} with a terminal
+ * reporter attached, so the reporter has a run to render — used to prove that render never reaches the
+ * real process stdout.
+ */
+#[Test]
+final class ReporterStub
+{
+    public function passes(): void
+    {
+        echo "reporter-stub-marker\n";
+        Assert::true(true);
+    }
+}

--- a/tests/Output/Unit/Json/JsonPluginTest.php
+++ b/tests/Output/Unit/Json/JsonPluginTest.php
@@ -65,12 +65,12 @@ final class JsonPluginTest
         }
     }
 
-    public function emptyOutputPathIsTreatedAsStdoutMode(): void
+    public function streamModeWritesTheReportToTheStream(): void
     {
         $stream = \fopen('php://memory', 'rb+');
         \assert($stream !== false);
 
-        self::dispatch(new JsonPlugin('', $stream), self::failedRun());
+        self::dispatch(new JsonPlugin($stream), self::failedRun());
 
         \rewind($stream);
         $written = (string) \stream_get_contents($stream);
@@ -88,7 +88,7 @@ final class JsonPluginTest
 
         try {
             $toFile = self::announcements(new JsonPlugin($path));
-            $toStdout = self::announcements(new JsonPlugin(null, $stream));
+            $toStdout = self::announcements(new JsonPlugin($stream));
 
             Assert::same(\array_map(
                 static fn(object $event): string => $event::class,

--- a/tests/Output/Unit/Teamcity/TeamcityLoggerTest.php
+++ b/tests/Output/Unit/Teamcity/TeamcityLoggerTest.php
@@ -32,6 +32,7 @@ use Testo\Core\Log\Message;
 use Testo\Core\Value\Status;
 use Testo\Core\Value\Summary;
 use Testo\Core\Report\ReportInfo;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Teamcity\Teamcity\TeamcityLogger;
 use Testo\Output\Terminal\Renderer\Style;
 use Testo\Test;
@@ -699,7 +700,7 @@ final class TeamcityLoggerTest
         \assert($stream !== false);
 
         try {
-            $callback(new TeamcityLogger($stream));
+            $callback(new TeamcityLogger(new ConsoleStreams($stream)));
             \rewind($stream);
             $output = \stream_get_contents($stream);
         } finally {

--- a/tests/Output/Unit/Teamcity/TeamcityPluginTest.php
+++ b/tests/Output/Unit/Teamcity/TeamcityPluginTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Output\Unit\Teamcity;
+
+use Internal\Container\ObjectContainer;
+use Internal\Path;
+use Testo\Application\Internal\EventDispatcher;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Common\EventListenerCollector;
+use Testo\Core\Context\CaseInfo;
+use Testo\Core\Context\Identity\SuiteIdentity;
+use Testo\Core\Context\TestInfo;
+use Testo\Core\Context\TestResult;
+use Testo\Core\Definition\CaseDefinition;
+use Testo\Core\Definition\TestDefinition;
+use Testo\Core\Value\Status;
+use Testo\Event\Test\TestBatchStarting;
+use Testo\Event\Test\TestDataSetStarting;
+use Testo\Event\Test\TestPipelineFinished;
+use Testo\Event\Test\TestPipelineStarting;
+use Testo\Event\Test\TestStarting;
+use Testo\Output\Teamcity\TeamcityPlugin;
+use Testo\Output\Terminal\Renderer\ColorMode;
+use Testo\Test;
+use Tests\Output\Stub\Teamcity\SampleTestClass;
+
+/**
+ * When the plugin announces a test as started to the CI server / IDE — the timing an IDE relies on to
+ * show a running spinner between `testStarted` and `testFinished`.
+ */
+#[Test]
+#[Covers(TeamcityPlugin::class)]
+final class TeamcityPluginTest
+{
+    public function aRegularTestIsAnnouncedStartedWhenItsBodyBeginsNotOnlyWhenItFinishes(): void
+    {
+        $info = self::makeInfo('passingTest');
+
+        // Stop at TestStarting: the body is now running but has not finished, and produced no output.
+        // A long, silent test sits here for its whole duration — so testStarted must already be out.
+        $output = self::drive(static function (EventDispatcher $dispatcher) use ($info): void {
+            $dispatcher->dispatch(new TestPipelineStarting($info));
+            $dispatcher->dispatch(new TestStarting($info));
+        });
+
+        Assert::string($output)->contains('##teamcity[testStarted');
+        Assert::string($output)->notContains('##teamcity[testFinished');
+    }
+
+    public function aSilentRegularTestStartsBeforeItFinishes(): void
+    {
+        $info = self::makeInfo('passingTest');
+
+        $output = self::drive(static function (EventDispatcher $dispatcher) use ($info): void {
+            $dispatcher->dispatch(new TestPipelineStarting($info));
+            $dispatcher->dispatch(new TestStarting($info));
+            $dispatcher->dispatch(new TestPipelineFinished($info, self::passed($info)));
+        });
+
+        $started = \strpos($output, '##teamcity[testStarted');
+        $finished = \strpos($output, '##teamcity[testFinished');
+
+        Assert::true($started !== false, 'testStarted must be emitted');
+        Assert::true($finished !== false, 'testFinished must be emitted');
+        Assert::true($started < $finished, 'testStarted must precede testFinished');
+    }
+
+    public function aDataSetBodyDoesNotEmitASecondTestStarted(): void
+    {
+        $info = self::makeInfo('passingTest');
+        $dataSet = $info->with(identity: $info->identity->toDataSet(dataProvider: 0, dataSet: 0));
+
+        // A data set gets its testStarted eagerly from TestDataSetStarting; the TestStarting fired for
+        // its body must not add a second one, or the IDE tree would carry a duplicate node.
+        $output = self::drive(static function (EventDispatcher $dispatcher) use ($info, $dataSet): void {
+            $dispatcher->dispatch(new TestPipelineStarting($info));
+            $dispatcher->dispatch(new TestBatchStarting($info));
+            $dispatcher->dispatch(new TestDataSetStarting($dataSet, '0', 0, 0));
+            $dispatcher->dispatch(new TestStarting($dataSet));
+        });
+
+        Assert::same(\substr_count($output, '##teamcity[testStarted'), 1);
+    }
+
+    /**
+     * Wires a fresh plugin to a fresh dispatcher writing to an in-memory stream, runs the scenario, and
+     * returns everything the plugin published.
+     *
+     * @param \Closure(EventDispatcher): void $scenario
+     */
+    private static function drive(\Closure $scenario): string
+    {
+        $stream = \fopen('php://memory', 'rb+');
+        \assert($stream !== false);
+
+        try {
+            $dispatcher = new EventDispatcher();
+            $container = new ObjectContainer();
+            $container->set($dispatcher, EventListenerCollector::class);
+            (new TeamcityPlugin(ColorMode::Never, $stream))->configure($container);
+
+            $scenario($dispatcher);
+
+            \rewind($stream);
+            $output = \stream_get_contents($stream);
+        } finally {
+            \fclose($stream);
+        }
+
+        return $output === false ? '' : $output;
+    }
+
+    private static function passed(TestInfo $info): TestResult
+    {
+        return new TestResult(info: $info, status: Status::Passed, attributes: ['duration' => 0]);
+    }
+
+    /**
+     * @param non-empty-string $method Method of {@see SampleTestClass} backing the test definition.
+     */
+    private static function makeInfo(string $method): TestInfo
+    {
+        return new TestInfo(
+            name: $method,
+            caseInfo: new CaseInfo(
+                suiteIdentity: new SuiteIdentity('Output/Unit'),
+                definition: new CaseDefinition(
+                    name: SampleTestClass::class,
+                    type: 'test',
+                    file: Path::create(__FILE__),
+                    reflection: new \ReflectionClass(SampleTestClass::class),
+                ),
+            ),
+            testDefinition: new TestDefinition(new \ReflectionMethod(SampleTestClass::class, $method)),
+        );
+    }
+}

--- a/tests/Output/Unit/Teamcity/TeamcityPluginTest.php
+++ b/tests/Output/Unit/Teamcity/TeamcityPluginTest.php
@@ -22,6 +22,7 @@ use Testo\Event\Test\TestDataSetStarting;
 use Testo\Event\Test\TestPipelineFinished;
 use Testo\Event\Test\TestPipelineStarting;
 use Testo\Event\Test\TestStarting;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Teamcity\TeamcityPlugin;
 use Testo\Output\Terminal\Renderer\ColorMode;
 use Testo\Test;
@@ -100,7 +101,8 @@ final class TeamcityPluginTest
             $dispatcher = new EventDispatcher();
             $container = new ObjectContainer();
             $container->set($dispatcher, EventListenerCollector::class);
-            (new TeamcityPlugin(ColorMode::Never, $stream))->configure($container);
+            $container->set(new ConsoleStreams($stream), ConsoleStreams::class);
+            (new TeamcityPlugin(ColorMode::Never))->configure($container);
 
             $scenario($dispatcher);
 

--- a/tests/Output/Unit/Terminal/TerminalLoggerTest.php
+++ b/tests/Output/Unit/Terminal/TerminalLoggerTest.php
@@ -30,6 +30,7 @@ use Testo\Core\Value\Status;
 use Testo\Core\Value\Summary;
 use Testo\Core\Value\Verbosity;
 use Testo\Data\MultipleResult;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Terminal\Renderer\OutputFormat;
 use Testo\Output\Terminal\Renderer\Style;
 use Testo\Output\Terminal\Renderer\TerminalLogger;
@@ -77,7 +78,7 @@ final class TerminalLoggerTest
         \assert($stdout !== false && $stderr !== false);
 
         try {
-            $logger = new TerminalLogger(OutputFormat::Compact, Verbosity::Normal, $stdout, $stderr);
+            $logger = new TerminalLogger(new ConsoleStreams($stdout, $stderr), OutputFormat::Compact, Verbosity::Normal);
             $logger->logMessage(new Message(0.0, Messenger::CHANNEL_STDERR, Level::Error, 'framework boom'));
 
             \rewind($stdout);
@@ -553,7 +554,7 @@ final class TerminalLoggerTest
         \assert($stream !== false);
 
         try {
-            $scenario(new TerminalLogger($format, $verbosity, $stream));
+            $scenario(new TerminalLogger(new ConsoleStreams($stream), $format, $verbosity));
             \rewind($stream);
             $output = \stream_get_contents($stream);
         } finally {
@@ -598,7 +599,7 @@ final class TerminalLoggerTest
         \assert($stream !== false);
 
         try {
-            $logger = new TerminalLogger(OutputFormat::Compact, $verbosity, $stream);
+            $logger = new TerminalLogger(new ConsoleStreams($stream), OutputFormat::Compact, $verbosity);
             foreach ($handled as $result) {
                 $logger->handleTestResult($result, 0);
             }
@@ -625,7 +626,7 @@ final class TerminalLoggerTest
         \assert($stream !== false);
 
         try {
-            $logger = new TerminalLogger(OutputFormat::Compact, Verbosity::Normal, $stream);
+            $logger = new TerminalLogger(new ConsoleStreams($stream), OutputFormat::Compact, Verbosity::Normal);
             $logger->batchStartedFromInfo($info);
             foreach ($datasets as $name => $result) {
                 $logger->testStartedFromInfo($info, $name);

--- a/tests/Output/Unit/Terminal/TerminalPluginTest.php
+++ b/tests/Output/Unit/Terminal/TerminalPluginTest.php
@@ -29,10 +29,9 @@ use Testo\Event\Test\TestBatchStarting;
 use Testo\Event\Test\TestDataSetFinished;
 use Testo\Event\Test\TestDataSetStarting;
 use Testo\Event\Test\TestPipelineFinished;
+use Testo\Output\ConsoleStreams;
 use Testo\Output\Terminal\Renderer\ColorMode;
-use Testo\Output\Terminal\Renderer\OutputFormat;
 use Testo\Output\Terminal\Renderer\Style;
-use Testo\Output\Terminal\Renderer\TerminalLogger;
 use Testo\Output\Terminal\TerminalPlugin;
 use Testo\Test;
 use Tests\Output\Stub\JUnit\SampleTestClass;
@@ -174,11 +173,12 @@ final class TerminalPluginTest
         $colors = Style::areColorsEnabled();
 
         try {
-            $logger = new TerminalLogger(OutputFormat::Compact, Verbosity::Verbose, $stdout, $stderr);
             $dispatcher = new EventDispatcher();
             $container = new ObjectContainer();
             $container->set($dispatcher, EventListenerCollector::class);
-            (new TerminalPlugin($logger, ColorMode::Never))->configure($container);
+            $container->set(new ConsoleStreams($stdout, $stderr), ConsoleStreams::class);
+            $container->set(Verbosity::Verbose, Verbosity::class);
+            (new TerminalPlugin(ColorMode::Never))->configure($container);
 
             $scenario($dispatcher);
 


### PR DESCRIPTION
## What was changed

Reporters (terminal, TeamCity, JSON) wrote through the `\STDOUT` / `\STDERR` constants, so a nested in-process run (the self-tests drive several) rendered onto the outer run's real stdout and corrupted the `--json` / `--teamcity` report a machine consumer parses. This branch introduces `ConsoleStreams`, one injectable stdout/stderr pair every reporter resolves from the container, so a run (or a test) redirects all output at once by rebinding that single pair. The Symfony bridge builds its own console output from the same pair, the CLI renderer is resolved inside the run scope so a plugin can redirect it before it renders, and `TestRunner` defaults its `ConsoleStreams` to an in-memory pair so a reporter a test activates never reaches the real stdout.

Also on this branch: the TeamCity plugin now emits `testStarted` on `TestStarting` (right before the body runs) instead of at pipeline finish; the libxml warning an invalid XPath raised during config inflation is silenced (it was noise on the machine-read stream); and `JsonPlugin`'s constructor takes a single `string|resource|null` argument in place of two mutually exclusive mode parameters. Subprocess leak guards drive nested runs under `--json` and assert stdout stays a single JSON object.

See commit history for details.

## Why?

`--json` and `--teamcity` are parsed by machines (LLM agents, CI, IDEs), so anything on stdout besides the report breaks them. A nested self-test run leaking terminal verse, or a stray libxml warning, did exactly that. Making `ConsoleStreams` the one seam where output goes lets any run redirect every reporter without reaching for the process constants. Separately, a long silent test received `testStarted` only at pipeline finish, back to back with `testFinished`, so an IDE showed nothing running and the test looked frozen until it was already over.

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation
